### PR TITLE
v1.7.0: token-guarded button callbacks + review fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,19 @@ When you show indefinite (`duration: 0`) popups, make the automation `mode: queu
 `continue_on_error: true` on the pipup actions — with the default `mode: single` a dismiss that
 fires while a show is still running is silently dropped, leaving the popup on screen.
 
+## Security
+
+PiPup runs an **unauthenticated** HTTP server on each TV, so any device on the network can show
+popups (including arbitrary JavaScript via a `web` popup). Keep PiPup TVs on a **trusted network
+segment**. See the [app's Security section](https://github.com/mhoogenbosch/PiPup#security).
+
+Button presses arrive over a local-only webhook. To stop a device on the LAN from forging a
+`pipup_button` event (which could drive a security-sensitive automation such as a door lock), this
+integration mints a **single-use token** for every button popup, passes it in the callback URL, and
+rejects any callback whose token is missing, unknown or expired. Traffic to the TV is plain HTTP, so
+the token can still be sniffed within its short window on an untrusted network — another reason to
+keep these devices on a segment you control.
+
 ## Troubleshooting
 
 - **"unsupported_version" while adding** — the TV runs the original PiPup; sideload the

--- a/custom_components/pipup/const.py
+++ b/custom_components/pipup/const.py
@@ -59,6 +59,10 @@ URGENCIES: Final = ["info", "warning", "critical"]
 # webhook that receives popup-button presses from the app; fires EVENT_BUTTON
 WEBHOOK_ID: Final = "pipup_buttons"
 EVENT_BUTTON: Final = "pipup_button"
+# hass.data key holding the single-use button-callback tokens
+DATA_BUTTON_TOKENS: Final = "button_tokens"
+# how long a button-callback token stays valid after the popup is shown
+BUTTON_TOKEN_TTL: Final = timedelta(minutes=15)
 
 CAMERA_MODE_STREAM: Final = "stream"
 CAMERA_MODE_MJPEG: Final = "mjpeg"

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.6.1",
+  "version": "1.7.0",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/notify.py
+++ b/custom_components/pipup/notify.py
@@ -14,7 +14,7 @@ from .api import PiPupError
 from .const import ATTR_MESSAGE, ATTR_TITLE
 from .coordinator import PiPupCoordinator
 from .entity import PiPupEntity
-from .services import _device_payload
+from .services import build_device_payload
 
 
 async def async_setup_entry(
@@ -46,7 +46,7 @@ class PiPupNotifyEntity(PiPupEntity, NotifyEntity):
         data = {ATTR_MESSAGE: message}
         if title:
             data[ATTR_TITLE] = title
-        payload = _device_payload(
+        payload = build_device_payload(
             data, dict(self.coordinator.config_entry.options), None
         )
         try:

--- a/custom_components/pipup/services.py
+++ b/custom_components/pipup/services.py
@@ -6,6 +6,7 @@ https://github.com/tonylofgren/aurora-smart-home
 from __future__ import annotations
 
 import logging
+import secrets
 from typing import Any
 
 import voluptuous as vol
@@ -17,6 +18,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.network import get_url
 from homeassistant.helpers.service import async_extract_config_entry_ids
+from homeassistant.util import dt as dt_util
 
 from .api import PiPupError
 from .const import (
@@ -43,6 +45,7 @@ from .const import (
     ATTR_URGENCY,
     ATTR_VIDEO_URL,
     ATTR_WEB_URL,
+    BUTTON_TOKEN_TTL,
     CAMERA_MODE_MJPEG,
     CAMERA_MODE_SNAPSHOT,
     CAMERA_MODE_STREAM,
@@ -56,6 +59,7 @@ from .const import (
     CONF_DEFAULT_POSITION,
     CONF_DEFAULT_TITLE_COLOR,
     CONF_DEFAULT_TITLE_SIZE,
+    DATA_BUTTON_TOKENS,
     DEFAULT_POSITION,
     DOMAIN,
     EVENT_BUTTON,
@@ -154,7 +158,7 @@ async def _coordinators_for_call(hass: HomeAssistant, call: ServiceCall) -> list
     return coordinators
 
 
-def _device_payload(
+def build_device_payload(
     data: dict[str, Any],
     opts: dict[str, Any],
     stream_uri: str | None,
@@ -174,8 +178,17 @@ def _device_payload(
         # 0 / "" mean "not configured" for sizes and colors
         return value if value not in (None, 0, 0.0, "") else fallback
 
+    # Duration is special: 0 is a meaningful value (show indefinitely), so only
+    # an absent default falls back — unlike sizes/colors where 0/"" mean "unset".
+    duration_default = opts.get(CONF_DEFAULT_DURATION)
     payload: dict[str, Any] = {
-        "duration": pick(ATTR_DURATION, CONF_DEFAULT_DURATION, 30),
+        "duration": (
+            data[ATTR_DURATION]
+            if ATTR_DURATION in data
+            else duration_default
+            if duration_default is not None
+            else 30
+        ),
         "position": POSITIONS[
             data.get(ATTR_POSITION)
             or opts.get(CONF_DEFAULT_POSITION, DEFAULT_POSITION)
@@ -266,10 +279,19 @@ async def _camera_media(
             async_sign_path,
         )
 
+        # An indefinite popup (duration <= 0) keeps the same signed URL open for
+        # as long as it is shown, so a 24 h signature would make the stream go
+        # 401 after a day. Sign such popups for much longer.
+        duration = data.get(ATTR_DURATION)
+        expiry = (
+            timedelta(days=30)
+            if duration is not None and duration <= 0
+            else timedelta(hours=24)
+        )
         signed = async_sign_path(
             hass,
             f"/api/camera_proxy_stream/{entity_id}",
-            timedelta(hours=24),
+            expiry,
         )
         return None, f"{base_url}{signed}", None
 
@@ -277,8 +299,42 @@ async def _camera_media(
     return f"{base_url}{stream_path}", None, None
 
 
+def _issue_button_token(hass: HomeAssistant, popup_id: str | None) -> str:
+    """Mint a single-use token for a button popup and remember it.
+
+    The token travels in the callback URL and must come back on the button
+    press, so a device on the LAN cannot forge a pipup_button event by POSTing
+    a guessed device id — which matters when button events drive things like a
+    door lock. Expired tokens are swept on each issue.
+    """
+    tokens: dict[str, dict[str, Any]] = hass.data.setdefault(DOMAIN, {}).setdefault(
+        DATA_BUTTON_TOKENS, {}
+    )
+    now = dt_util.utcnow()
+    for tok in [t for t, meta in tokens.items() if meta["expires"] < now]:
+        tokens.pop(tok, None)
+    token = secrets.token_urlsafe(24)
+    tokens[token] = {"popup_id": popup_id, "expires": now + BUTTON_TOKEN_TTL}
+    return token
+
+
 async def _handle_button_webhook(hass: HomeAssistant, webhook_id: str, request) -> None:
-    """Fire a pipup_button event for a button press POSTed by the app."""
+    """Fire a pipup_button event for a button press POSTed by the app.
+
+    The press is only honored when it carries a valid, unexpired, single-use
+    token that this integration handed out when it showed the popup.
+    """
+    token = request.query.get("token")
+    tokens: dict[str, dict[str, Any]] = hass.data.get(DOMAIN, {}).get(
+        DATA_BUTTON_TOKENS, {}
+    )
+    meta = tokens.pop(token, None) if token else None
+    if meta is None or meta["expires"] < dt_util.utcnow():
+        _LOGGER.warning(
+            "Rejecting PiPup button callback with missing/invalid/expired token"
+        )
+        return
+
     try:
         data = await request.json()
     except ValueError:
@@ -323,15 +379,32 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if data.get(ATTR_CAMERA_ENTITY):
             stream_uri, web_uri, snapshot = await _camera_media(hass, data)
 
-        callback_url: str | None = None
-        if data.get(ATTR_BUTTONS):
-            base_url = get_url(hass, allow_external=False, prefer_external=False)
-            callback_url = f"{base_url}/api/webhook/{WEBHOOK_ID}"
+        # Buttons can't ride along in the multipart/snapshot request, so warn
+        # instead of silently dropping them (the app's multipart parser has no
+        # buttons/urgency/showProgress field).
+        if data.get(ATTR_BUTTONS) and snapshot is not None:
+            _LOGGER.warning(
+                "PiPup: buttons are ignored when camera_mode is 'snapshot' "
+                "(multipart upload). Use mjpeg/stream or an image_url for buttons."
+            )
+
+        want_buttons = bool(data.get(ATTR_BUTTONS)) and snapshot is None
+        base_url = (
+            get_url(hass, allow_external=False, prefer_external=False)
+            if want_buttons
+            else None
+        )
 
         errors: list[str] = []
         for coordinator in coordinators:
             opts = dict(coordinator.config_entry.options)
-            payload = _device_payload(data, opts, stream_uri, web_uri, callback_url)
+            # A fresh single-use token per device: the button press must return
+            # it in the callback URL for the pipup_button event to fire.
+            callback_url: str | None = None
+            if want_buttons:
+                token = _issue_button_token(hass, data.get(ATTR_POPUP_ID))
+                callback_url = f"{base_url}/api/webhook/{WEBHOOK_ID}?token={token}"
+            payload = build_device_payload(data, opts, stream_uri, web_uri, callback_url)
             try:
                 if snapshot is not None:
                     fields = {

--- a/custom_components/pipup/update.py
+++ b/custom_components/pipup/update.py
@@ -14,7 +14,9 @@ from homeassistant.components.update import UpdateEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util import dt as dt_util
 
+from .const import DOMAIN
 from .coordinator import PiPupCoordinator
 from .entity import PiPupEntity
 
@@ -24,6 +26,35 @@ _LOGGER = logging.getLogger(__name__)
 RELEASES_URL = "https://api.github.com/repos/mhoogenbosch/PiPup/releases/latest"
 RELEASE_PAGE = "https://github.com/mhoogenbosch/PiPup/releases"
 SCAN_INTERVAL = timedelta(hours=6)
+# One TV per config entry, but the latest release is the same for all of them —
+# cache it process-wide so N TVs make one GitHub call per interval, not N.
+_CACHE_KEY = "latest_release_cache"
+_CACHE_TTL = timedelta(hours=6)
+
+
+async def _latest_release_tag(hass: HomeAssistant) -> str | None:
+    """Return the latest fork release tag (without leading v), cached per TTL."""
+    cache = hass.data.setdefault(DOMAIN, {}).get(_CACHE_KEY)
+    now = dt_util.utcnow()
+    if cache and cache["expires"] > now:
+        return cache["tag"]
+
+    session = async_get_clientsession(hass)
+    try:
+        async with session.get(
+            RELEASES_URL, timeout=aiohttp.ClientTimeout(total=15)
+        ) as resp:
+            if resp.status != 200:
+                _LOGGER.debug("GitHub releases returned %s", resp.status)
+                return cache["tag"] if cache else None
+            data = await resp.json()
+    except (aiohttp.ClientError, TimeoutError) as err:
+        _LOGGER.debug("Could not fetch latest PiPup release: %s", err)
+        return cache["tag"] if cache else None
+
+    tag = (data.get("tag_name") or "").lstrip("v") or None
+    hass.data[DOMAIN][_CACHE_KEY] = {"tag": tag, "expires": now + _CACHE_TTL}
+    return tag
 
 
 async def async_setup_entry(
@@ -59,19 +90,5 @@ class PiPupUpdateEntity(PiPupEntity, UpdateEntity):
         return self._latest
 
     async def async_update(self) -> None:
-        """Fetch the latest release tag (every SCAN_INTERVAL)."""
-        session = async_get_clientsession(self.hass)
-        try:
-            async with session.get(
-                RELEASES_URL, timeout=aiohttp.ClientTimeout(total=15)
-            ) as resp:
-                if resp.status != 200:
-                    _LOGGER.debug("GitHub releases returned %s", resp.status)
-                    return
-                data = await resp.json()
-        except (aiohttp.ClientError, TimeoutError) as err:
-            _LOGGER.debug("Could not fetch latest PiPup release: %s", err)
-            return
-
-        tag = data.get("tag_name") or ""
-        self._latest = tag.lstrip("v") or None
+        """Refresh the latest release tag from the shared cache."""
+        self._latest = await _latest_release_tag(self.hass)


### PR DESCRIPTION
Code-review follow-up (integration side).

- **Security — token-guarded button callbacks**: the `pipup_button` webhook accepted any local POST with a guessable device id, which could forge a door-unlock event. Now each button popup gets a single-use, 15-min token passed in the callback URL; the webhook rejects missing/unknown/expired tokens.
- **MJPEG indefinite popups**: `duration <= 0` signs the camera-proxy URL for 30 days instead of 24 h (was going 401 after a day).
- **Snapshot + buttons**: warns instead of silently dropping buttons (the multipart path has no buttons field).
- **Update entity**: process-wide cache for the latest release — N TVs → one GitHub call per interval.
- **`duration: 0` device default** now means indefinite instead of falling back to 30 s; `_device_payload` → `build_device_payload` (shared with notify).
- README Security section.

HACS + hassfest run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)