### PR TITLE
v1.8.2: make the update entity actually poll again

### DIFF
--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.8.1",
+  "version": "1.8.2",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/update.py
+++ b/custom_components/pipup/update.py
@@ -28,7 +28,11 @@ _LOGGER = logging.getLogger(__name__)
 # GitHub releases of the PiPup fork; polled sparingly (anonymous rate limit).
 RELEASES_URL = "https://api.github.com/repos/mhoogenbosch/PiPup/releases/latest"
 RELEASE_PAGE = "https://github.com/mhoogenbosch/PiPup/releases"
-SCAN_INTERVAL = timedelta(hours=6)
+# How often each entity re-reads the shared cache. Deliberately shorter than the
+# cache TTL: a poll that finds a live cache entry costs nothing, so a short
+# interval only means a refreshed tag reaches every TV quickly. Equal values
+# would let an entity sit a full cycle behind a cache another entity refreshed.
+SCAN_INTERVAL = timedelta(hours=1)
 # One TV per config entry, but the latest release is the same for all of them —
 # cache it process-wide so N TVs make one GitHub call per interval, not N.
 _CACHE_KEY = "latest_release_cache"
@@ -79,12 +83,25 @@ class PiPupUpdateEntity(PiPupEntity, UpdateEntity):
 
     _attr_translation_key = "app_update"
     _attr_release_url = RELEASE_PAGE
-    _attr_should_poll = True
 
     def __init__(self, coordinator: PiPupCoordinator, entry) -> None:
         """Initialize the update entity."""
         super().__init__(coordinator, entry, "app_update")
         self._latest: str | None = None
+
+    @property
+    def should_poll(self) -> bool:
+        """Poll, unlike the other entities on this coordinator.
+
+        This has to be a property. CoordinatorEntity declares should_poll as a
+        cached_property returning False — correct for entities whose data comes
+        from the coordinator, but this one also has to reach GitHub, which the
+        coordinator knows nothing about. A class-level `_attr_should_poll = True`
+        loses to that property and is silently ignored, which is exactly what
+        happened up to 1.8.1: async_update ran once at setup and never again, so
+        latest_version froze at whatever it was when Home Assistant started.
+        """
+        return True
 
     @property
     def installed_version(self) -> str | None:


### PR DESCRIPTION
## What was wrong

`CoordinatorEntity` declares `should_poll` as a `cached_property` returning `False`. The class-level
`_attr_should_poll = True` on `PiPupUpdateEntity` loses to that property and is silently ignored, so
`async_update()` only ever ran once — through `update_before_add` at setup.

The consequence: `latest_version` froze at whatever GitHub reported when Home Assistant started. Neither the
6-hour cache nor the stale-cache bypass added in 1.8.1 was ever consulted again.

Measured on a live install: 22 minutes after the shared cache already held `0.6.2`, seven of eight TVs still
reported `0.6.1`. Verified against core 2026.7.4, `homeassistant/helpers/update_coordinator.py` lines 648-652.

## Changes

- `should_poll` overridden as a real property returning `True`, with a comment explaining why it cannot be an
  `_attr_` — that is the trap that produced this bug.
- `SCAN_INTERVAL` shortened from 6h to 1h. A poll that finds a live cache entry costs nothing, so the shorter
  interval only propagates a refreshed tag to every TV faster. The 6h cache TTL still caps GitHub traffic at
  one call per six hours no matter how many TVs are configured. Equal values let an entity sit a full cycle
  behind a cache that another entity had already refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)