### PR TITLE
ci: stop docs-only PRs from blocking on validation

### DIFF
--- a/.github/workflows/validate-docs.yaml
+++ b/.github/workflows/validate-docs.yaml
@@ -1,0 +1,26 @@
+name: Validate (docs)
+
+# Branch protection requires the "validate" status check on main. A required check
+# that never runs leaves a pull request blocked forever, so documentation-only
+# changes — which validate.yaml skips via paths-ignore — get the same check
+# reported by this no-op job instead.
+#
+# Keep the path list here in sync with the paths-ignore list in validate.yaml.
+
+on:
+  pull_request:
+    paths:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: No code changed
+        run: echo "Documentation-only change — HACS/hassfest validation not needed."

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -3,10 +3,25 @@
 name: Validate
 
 on:
+  # Default branch only. A push to a pull-request branch would otherwise start a
+  # second run for the same commit, and the loser of that race reports a
+  # cancelled "validate" check that blocks the pull request indefinitely.
   push:
+    branches: [main]
   pull_request:
+    # Documentation-only changes are covered by validate-docs.yaml, which reports
+    # the same required "validate" check without running HACS/hassfest.
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.gitignore'
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   validate:


### PR DESCRIPTION
## English

Two CI problems made a readme-only pull request unmergeable (hit while documenting the TCL keep-alive automation in #3).

1. **Duplicate runs fighting over the required check.** The workflow triggered on `push` (any branch) *and* `pull_request`, so every commit on a PR branch started two runs reporting the same required `validate` check. One passed in 2 minutes; the other was cancelled after 15 and turned the required context red, leaving the PR blocked. Push is now limited to `main`, plus a `concurrency` group that cancels superseded runs.
2. **Docs had to pass full validation.** HACS/hassfest ran for a pure documentation change. Those paths are now excluded via `paths-ignore`, and a new `validate-docs.yaml` reports the same `validate` check for them.

The second workflow exists on purpose: a required status check that simply *never runs* blocks a pull request forever, so `paths-ignore` alone would have made things worse rather than better. Keep both path lists in sync — noted in a comment in each file.

## Nederlands

Twee CI-problemen maakten een readme-only PR onmergebaar (gevonden bij het documenteren van de TCL keep-alive-automation in #3).

1. **Dubbele runs die om dezelfde required check vechten.** De workflow triggerde op `push` (élke branch) én `pull_request`, dus elke commit op een PR-branch startte twee runs die dezelfde verplichte `validate`-check rapporteren. Eén slaagde in 2 minuten, de ander werd na 15 minuten gecanceld en zette de required context op rood — PR geblokkeerd. Push is nu beperkt tot `main`, plus een `concurrency`-groep die achterhaalde runs afbreekt.
2. **Docs moesten door de volledige validatie.** HACS/hassfest liep voor een pure documentatiewijziging. Die paden zijn nu uitgesloten via `paths-ignore`, en een nieuwe `validate-docs.yaml` levert dezelfde `validate`-check voor die paden.

Die tweede workflow is bewust: een verplichte status check die simpelweg *niet draait* blokkeert een PR voor altijd — alleen `paths-ignore` toevoegen zou het dus erger maken. Houd beide padlijsten gelijk; dat staat als commentaar in beide bestanden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)