### PR TITLE
v1.9.0: screen switch, custom border styling, permission reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
   - **PiPup app** update entity — checks the fork's GitHub releases and, with app >= 0.6.0,
     the **Install** button makes the TV update itself (silent on Android 12+, system
     confirmation on older devices)
+  - **Screen** switch (app ≥ 0.7.0) — turns the TV on (wake) and off (standby) straight through
+    PiPup, so this no longer needs a second ADB/CEC integration. Attributes `can_sleep` and
+    `sleep_method` say what the device can actually do: turning **on** always works, turning **off**
+    needs a one-time adb grant on the TV (see [screen on/off](#screen-onoff))
+  - **Permission problem** diagnostic binary sensor (app ≥ 0.7.0) — on when the app misses a
+    permission it needs, with each grant as an attribute. Without the overlay app-op the TV accepts
+    every popup with HTTP 200 and shows *nothing*, and `adb install -r` resets it, so this also
+    raises a **repair** with the command to fix it
   - **App uptime** diagnostic sensor and a diagnostics download
 - Action **`pipup.show`** — title/message/media popup with all PiPup fields, plus:
   - `duration: 0` → popup stays until dismissed or replaced
@@ -50,6 +58,11 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
     needed; see the doorbell example below
   - `show_progress` → animated countdown bar for finite durations (app ≥ 0.3.0)
   - `urgency` → `info`/`warning`/`critical` colored border presets (app ≥ 0.3.0)
+  - `border_color`, `border_width`, `corner_radius` → style the frame yourself (app ≥ 0.7.0). Each
+    overrides *its part* of the `urgency` preset, so they combine: `urgency: critical` with
+    `border_width: 2` is a thin red border, and `border_width: 0` drops the preset's frame.
+    `corner_radius` also works without a border. Sizes are in pixels, and all three are available as
+    **per-device defaults** too
 - Action **`pipup.dismiss`** — remove the popup, optionally only when it has a given `popup_id`.
 
 ## Installation
@@ -73,8 +86,30 @@ working when the TV gets a different DHCP address.
 Manual fallback (older app, or discovery blocked between VLANs): Settings → Devices & Services →
 Add Integration → **PiPup** → enter the TV's IP and port (default 7979).
 
-Per-TV popup defaults (position, duration, muted, sizes, colors) live under *Configure* on each
-entry; action fields override them per call.
+Per-TV popup defaults (position, duration, muted, sizes, colors, border styling) live under
+*Configure* on each entry; action fields override them per call. Note the difference for the two
+numeric border fields: **empty** means "no default", while **0** is a real value (no border /
+square corners).
+
+### Screen on/off
+
+The **Screen** switch needs app ≥ 0.7.0. Turning the TV *on* works out of the box. Turning it *off*
+is something no sideloaded app may do on its own, so grant one of the two routes once per TV — the
+installer script in the PiPup release does this with `--power`:
+
+```bash
+adb shell dpm set-active-admin nl.rogro82.pipup/.AdminReceiver
+```
+
+Devices without the device-admin feature (a fair number of Android TV boxes; `dpm` still prints
+`Success` there while registering nothing) use the accessibility fallback instead — see the
+[PiPup readme](https://github.com/mhoogenbosch/PiPup#screen-onoff). The switch reports which route
+is active in its `sleep_method` attribute, and `turn_off` on a TV without any route raises an error
+naming the fix rather than failing silently.
+
+Because the app derives the screen state from `PowerManager.isInteractive`, which lags a poll behind
+a fresh wake, the switch trusts its own last command for up to 20 seconds and schedules an extra
+refresh — so it does not visibly bounce back after you flip it.
 
 ## Examples
 

--- a/custom_components/pipup/__init__.py
+++ b/custom_components/pipup/__init__.py
@@ -29,6 +29,7 @@ PLATFORMS: list[Platform] = [
     Platform.NOTIFY,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.UPDATE,
 ]
 

--- a/custom_components/pipup/api.py
+++ b/custom_components/pipup/api.py
@@ -107,6 +107,34 @@ class PiPupClient:
         except (aiohttp.ClientError, TimeoutError) as err:
             raise PiPupError(f"Cannot reach PiPup at {self._base}: {err}") from err
 
+    async def power(self, state: str) -> dict[str, Any]:
+        """Turn the device's screen on or off (app >= 0.7.0).
+
+        The app answers 501 when it has no granted way to turn the screen off
+        (no device admin, no accessibility service) and 400 when it predates
+        /power entirely - both surface as PiPupUnsupportedError, so the caller
+        can tell "this device cannot" apart from a network failure.
+        """
+        try:
+            async with self._session.post(
+                f"{self._base}/power",
+                params={"state": state},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status in (400, 501):
+                    body = await resp.text()
+                    raise PiPupUnsupportedError(
+                        f"device cannot switch its screen {state}: {body}"
+                    )
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise PiPupError(f"power failed ({resp.status}): {body}")
+                return await resp.json(content_type=None)
+        except PiPupError:
+            raise
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise PiPupError(f"Cannot reach PiPup at {self._base}: {err}") from err
+
     async def cancel(self, popup_id: str | None = None) -> None:
         """Dismiss the current popup, optionally only when popup_id matches."""
         params = {"id": popup_id} if popup_id else None

--- a/custom_components/pipup/binary_sensor.py
+++ b/custom_components/pipup/binary_sensor.py
@@ -33,6 +33,9 @@ async def async_setup_entry(
     # Needs the fork app >= 0.2.3.
     if "screenOn" in coordinator.data:
         entities.append(PiPupScreenSensor(coordinator, entry))
+    # Needs the fork app >= 0.7.0.
+    if isinstance(coordinator.data.get("permissions"), dict):
+        entities.append(PiPupPermissionSensor(coordinator, entry))
     async_add_entities(entities)
 
 
@@ -83,6 +86,53 @@ class PiPupScreenSensor(PiPupEntity, BinarySensorEntity):
             return None
         value = self.coordinator.data.get("screenOn")
         return bool(value) if value is not None else None
+
+
+class PiPupPermissionSensor(PiPupEntity, BinarySensorEntity):
+    """Problem sensor: on when the app misses a permission it needs (app >= 0.7.0).
+
+    Worth an entity because this failure is otherwise invisible: without the overlay
+    app-op the TV accepts every popup with HTTP 200 and simply shows nothing. The
+    app-ops also reset on each reinstall, so this can come back after an update.
+    """
+
+    _attr_translation_key = "permissions"
+    _attr_device_class = BinarySensorDeviceClass.PROBLEM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: PiPupCoordinator, entry) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, entry, "permissions")
+
+    @property
+    def _permissions(self) -> dict[str, Any]:
+        value = self.coordinator.data.get("permissions")
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return True when a required permission is missing."""
+        if not self.coordinator.online:
+            return None
+        complete = self._permissions.get("complete")
+        return not complete if complete is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose each grant separately.
+
+        ``auto_start`` is None on every device without TCL's vendor app-op; that is
+        "not applicable", not a missing grant, and it is deliberately not part of
+        the problem state.
+        """
+        permissions = self._permissions
+        return {
+            "overlay": permissions.get("overlay"),
+            "install_packages": permissions.get("installPackages"),
+            "auto_start": permissions.get("autoStart"),
+            "device_admin": permissions.get("deviceAdmin"),
+            "accessibility": permissions.get("accessibility"),
+        }
 
 
 class PiPupConnectivitySensor(PiPupEntity, BinarySensorEntity):

--- a/custom_components/pipup/config_flow.py
+++ b/custom_components/pipup/config_flow.py
@@ -23,6 +23,9 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from .api import PiPupClient, PiPupError, PiPupUnsupportedError
 from .const import (
     CONF_DEFAULT_BACKGROUND_COLOR,
+    CONF_DEFAULT_BORDER_COLOR,
+    CONF_DEFAULT_BORDER_WIDTH,
+    CONF_DEFAULT_CORNER_RADIUS,
     CONF_DEFAULT_DURATION,
     CONF_DEFAULT_MEDIA_HEIGHT,
     CONF_DEFAULT_MEDIA_WIDTH,
@@ -212,12 +215,22 @@ class PiPupOptionsFlow(OptionsFlow):
                 CONF_DEFAULT_TITLE_COLOR,
                 CONF_DEFAULT_MESSAGE_COLOR,
                 CONF_DEFAULT_BACKGROUND_COLOR,
+                CONF_DEFAULT_BORDER_COLOR,
             ):
                 value = (user_input.get(key) or "").strip()
                 if value:
                     options[key] = value
                 else:
                     options.pop(key, None)
+            # Border width and corner radius have no "0 means unset" escape - 0 is a
+            # real value there (no border / square corners). An empty field therefore
+            # removes the default instead of storing a zero.
+            for key in (CONF_DEFAULT_BORDER_WIDTH, CONF_DEFAULT_CORNER_RADIUS):
+                value = user_input.get(key)
+                if value is None:
+                    options.pop(key, None)
+                else:
+                    options[key] = value
             return self.async_create_entry(title="", data=options)
 
         opts = self.config_entry.options
@@ -285,6 +298,26 @@ class PiPupOptionsFlow(OptionsFlow):
                             )
                         },
                     ): str,
+                    vol.Optional(
+                        CONF_DEFAULT_BORDER_COLOR,
+                        description={
+                            "suggested_value": opts.get(CONF_DEFAULT_BORDER_COLOR, "")
+                        },
+                    ): str,
+                    # deliberately no default=: an empty field means "no default",
+                    # which is not the same as 0 (= no border / square corners)
+                    vol.Optional(
+                        CONF_DEFAULT_BORDER_WIDTH,
+                        description={
+                            "suggested_value": opts.get(CONF_DEFAULT_BORDER_WIDTH)
+                        },
+                    ): vol.All(vol.Coerce(int), vol.Range(min=0, max=64)),
+                    vol.Optional(
+                        CONF_DEFAULT_CORNER_RADIUS,
+                        description={
+                            "suggested_value": opts.get(CONF_DEFAULT_CORNER_RADIUS)
+                        },
+                    ): vol.All(vol.Coerce(float), vol.Range(min=0, max=128)),
                 }
             ),
         )

--- a/custom_components/pipup/const.py
+++ b/custom_components/pipup/const.py
@@ -23,6 +23,9 @@ CONF_DEFAULT_TITLE_SIZE: Final = "default_title_size"
 CONF_DEFAULT_MESSAGE_COLOR: Final = "default_message_color"
 CONF_DEFAULT_MESSAGE_SIZE: Final = "default_message_size"
 CONF_DEFAULT_BACKGROUND_COLOR: Final = "default_background_color"
+CONF_DEFAULT_BORDER_COLOR: Final = "default_border_color"
+CONF_DEFAULT_BORDER_WIDTH: Final = "default_border_width"
+CONF_DEFAULT_CORNER_RADIUS: Final = "default_corner_radius"
 CONF_NAME_SUFFIX: Final = "name_suffix"
 # internal marker: which suffix we last applied to the entity registry names
 CONF_NAME_SUFFIX_APPLIED: Final = "name_suffix_applied"
@@ -53,6 +56,10 @@ ATTR_TTS_LANGUAGE: Final = "tts_language"
 ATTR_BUTTONS: Final = "buttons"
 ATTR_SHOW_PROGRESS: Final = "show_progress"
 ATTR_URGENCY: Final = "urgency"
+# app >= 0.7.0: explicit border styling, each overriding its part of `urgency`
+ATTR_BORDER_COLOR: Final = "border_color"
+ATTR_BORDER_WIDTH: Final = "border_width"
+ATTR_CORNER_RADIUS: Final = "corner_radius"
 
 URGENCIES: Final = ["info", "warning", "critical"]
 
@@ -63,6 +70,18 @@ EVENT_BUTTON: Final = "pipup_button"
 DATA_BUTTON_TOKENS: Final = "button_tokens"
 # how long a button-callback token stays valid after the popup is shown
 BUTTON_TOKEN_TTL: Final = timedelta(minutes=15)
+
+# screen on/off (app >= 0.7.0): /state publishes what the device can actually do
+POWER_STATE_ON: Final = "on"
+POWER_STATE_OFF: Final = "off"
+# how long the screen switch trusts its own optimistic state: the app's screenOn
+# comes from PowerManager.isInteractive and lags a poll behind a fresh wake
+POWER_OPTIMISTIC_TTL: Final = timedelta(seconds=20)
+# extra refresh after a power call, to pick up the real state once it settled
+POWER_SETTLE_DELAY: Final = 5
+
+# repair issue raised when the overlay app-op is missing (popups stay invisible)
+ISSUE_NO_OVERLAY: Final = "no_overlay_permission"
 
 CAMERA_MODE_STREAM: Final = "stream"
 CAMERA_MODE_MJPEG: Final = "mjpeg"

--- a/custom_components/pipup/coordinator.py
+++ b/custom_components/pipup/coordinator.py
@@ -12,6 +12,7 @@ from typing import Any
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -19,7 +20,12 @@ from homeassistant.helpers.update_coordinator import (
 )
 
 from .api import PiPupClient, PiPupError
-from .const import CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import (
+    CONF_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    ISSUE_NO_OVERLAY,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +49,8 @@ class PiPupCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entry.data[CONF_PORT],
         )
         self.online = False
+        # tri-state: None = not yet known, so the first poll always evaluates
+        self._overlay_ok: bool | None = None
 
         scan_interval = entry.options.get(CONF_SCAN_INTERVAL)
         update_interval = (
@@ -72,7 +80,42 @@ class PiPupCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             _LOGGER.debug("PiPup at %s unreachable: %s", self.client.host, err)
             return self.data
         self.online = True
+        self._check_overlay_permission(data)
         return data
+
+    def _check_overlay_permission(self, data: dict[str, Any]) -> None:
+        """Raise/clear a repair issue for a missing overlay app-op (app >= 0.7.0).
+
+        Without SYSTEM_ALERT_WINDOW the TV answers every popup with HTTP 200 and
+        shows nothing, so nothing else in HA would ever reveal this. The app-op also
+        resets on every reinstall, hence a repair rather than a one-off log line.
+        Only touched on a change: the registry is not a polling target.
+        """
+        permissions = data.get("permissions")
+        if not isinstance(permissions, dict):
+            return  # older app: it cannot tell us
+        overlay = permissions.get("overlay")
+        if overlay is None or overlay == self._overlay_ok:
+            return
+
+        self._overlay_ok = bool(overlay)
+        issue_id = f"{ISSUE_NO_OVERLAY}_{self.config_entry.entry_id}"
+        if overlay:
+            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+        ir.async_create_issue(
+            self.hass,
+            DOMAIN,
+            issue_id,
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_NO_OVERLAY,
+            translation_placeholders={
+                "name": self.config_entry.title,
+                "host": self.client.host,
+            },
+            learn_more_url="https://github.com/mhoogenbosch/PiPup#install",
+        )
 
     async def async_refresh_soon(self) -> None:
         """Refresh state right after a show/dismiss call."""

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.8.2",
+  "version": "1.9.0",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/services.py
+++ b/custom_components/pipup/services.py
@@ -23,9 +23,12 @@ from homeassistant.util import dt as dt_util
 from .api import PiPupError
 from .const import (
     ATTR_BACKGROUND_COLOR,
+    ATTR_BORDER_COLOR,
+    ATTR_BORDER_WIDTH,
     ATTR_BUTTONS,
     ATTR_CAMERA_ENTITY,
     ATTR_CAMERA_MODE,
+    ATTR_CORNER_RADIUS,
     ATTR_DURATION,
     ATTR_IMAGE_URL,
     ATTR_MEDIA_HEIGHT,
@@ -50,6 +53,9 @@ from .const import (
     CAMERA_MODE_SNAPSHOT,
     CAMERA_MODE_STREAM,
     CONF_DEFAULT_BACKGROUND_COLOR,
+    CONF_DEFAULT_BORDER_COLOR,
+    CONF_DEFAULT_BORDER_WIDTH,
+    CONF_DEFAULT_CORNER_RADIUS,
     CONF_DEFAULT_DURATION,
     CONF_DEFAULT_MEDIA_HEIGHT,
     CONF_DEFAULT_MEDIA_WIDTH,
@@ -105,6 +111,13 @@ SHOW_SCHEMA = vol.Schema(
         vol.Optional(ATTR_TTS): cv.string,
         vol.Optional(ATTR_TTS_LANGUAGE): cv.string,
         vol.Optional(ATTR_URGENCY): vol.In(URGENCIES),
+        vol.Optional(ATTR_BORDER_COLOR): vol.Match(COLOR_REGEX),
+        vol.Optional(ATTR_BORDER_WIDTH): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=64)
+        ),
+        vol.Optional(ATTR_CORNER_RADIUS): vol.All(
+            vol.Coerce(float), vol.Range(min=0, max=128)
+        ),
         vol.Optional(ATTR_SHOW_PROGRESS): cv.boolean,
         vol.Optional(ATTR_BUTTONS): vol.All(
             cv.ensure_list,
@@ -178,6 +191,17 @@ def build_device_payload(
         # 0 / "" mean "not configured" for sizes and colors
         return value if value not in (None, 0, 0.0, "") else fallback
 
+    def pick_numeric(attr: str, conf: str) -> Any:
+        """Like pick(), but for fields where 0 is a real value.
+
+        borderWidth 0 = no border (also switches an urgency border off) and
+        cornerRadius 0 = square corners, so only a genuinely absent value may
+        fall through to the app's own default.
+        """
+        if attr in data:
+            return data[attr]
+        return opts.get(conf)
+
     # Duration is special: 0 is a meaningful value (show indefinitely), so only
     # an absent default falls back — unlike sizes/colors where 0/"" mean "unset".
     duration_default = opts.get(CONF_DEFAULT_DURATION)
@@ -214,6 +238,16 @@ def build_device_payload(
         payload["buttons"] = buttons
         if callback_url:
             payload["callback"] = callback_url
+
+    # app >= 0.7.0: explicit border styling. Each field overrides its part of the
+    # urgency preset, so the two can be combined (critical + thin border, or
+    # border_width 0 to keep the preset's semantics without its frame).
+    if color := pick(ATTR_BORDER_COLOR, CONF_DEFAULT_BORDER_COLOR, None):
+        payload["borderColor"] = color
+    if (width_px := pick_numeric(ATTR_BORDER_WIDTH, CONF_DEFAULT_BORDER_WIDTH)) is not None:
+        payload["borderWidth"] = width_px
+    if (radius := pick_numeric(ATTR_CORNER_RADIUS, CONF_DEFAULT_CORNER_RADIUS)) is not None:
+        payload["cornerRadius"] = radius
 
     if color := pick(ATTR_TITLE_COLOR, CONF_DEFAULT_TITLE_COLOR, None):
         payload["titleColor"] = color

--- a/custom_components/pipup/services.yaml
+++ b/custom_components/pipup/services.yaml
@@ -51,6 +51,24 @@ show:
             - warning
             - critical
           translation_key: urgency
+    border_color:
+      example: "#00E5FF"
+      selector:
+        text:
+    border_width:
+      selector:
+        number:
+          min: 0
+          max: 64
+          unit_of_measurement: px
+          mode: box
+    corner_radius:
+      selector:
+        number:
+          min: 0
+          max: 128
+          unit_of_measurement: px
+          mode: box
     show_progress:
       selector:
         boolean:

--- a/custom_components/pipup/strings.json
+++ b/custom_components/pipup/strings.json
@@ -50,7 +50,10 @@
           "default_message_size": "Default message size (0 = app default)",
           "default_title_color": "Default title color (#RRGGBB, empty = app default)",
           "default_message_color": "Default message color (#RRGGBB, empty = app default)",
-          "default_background_color": "Default background color (#AARRGGBB, empty = app default)"
+          "default_background_color": "Default background color (#AARRGGBB, empty = app default)",
+          "default_border_color": "Default border color (empty = none)",
+          "default_border_width": "Default border width in px (empty = none)",
+          "default_corner_radius": "Default corner radius in px (empty = none)"
         },
         "data_description": {
           "name_suffix": "Appended to all entity names of this device (e.g. \"Veranda\" gives \"Popup Veranda\") so multiple TVs stay distinguishable in pickers."
@@ -68,6 +71,9 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "permissions": {
+        "name": "Permission problem"
       }
     },
     "notify": {
@@ -106,6 +112,11 @@
     "update": {
       "app_update": {
         "name": "PiPup app"
+      }
+    },
+    "switch": {
+      "screen_power": {
+        "name": "Screen"
       }
     }
   },
@@ -223,6 +234,18 @@
           "name": "Urgency",
           "description": "Styling preset: colored border by severity (app 0.3.0 or newer)."
         },
+        "border_color": {
+          "name": "Border color",
+          "description": "Border color as #RRGGBB or #AARRGGBB. Overrides the urgency preset's color."
+        },
+        "border_width": {
+          "name": "Border width",
+          "description": "Border thickness in pixels. 0 removes the border, also the urgency preset's one."
+        },
+        "corner_radius": {
+          "name": "Corner radius",
+          "description": "Rounded corners in pixels. Works without a border too; 0 keeps them square."
+        },
         "show_progress": {
           "name": "Show countdown bar",
           "description": "Animated bar showing the remaining duration (finite durations only; app 0.3.0 or newer)."
@@ -242,6 +265,12 @@
           "description": "Only dismiss when the visible popup has this ID."
         }
       }
+    }
+  },
+  "issues": {
+    "no_overlay_permission": {
+      "title": "PiPup {name} misses the overlay permission",
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
     }
   }
 }

--- a/custom_components/pipup/switch.py
+++ b/custom_components/pipup/switch.py
@@ -1,0 +1,121 @@
+"""Switch: the TV's screen on/off (app >= 0.7.0)."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+from homeassistant.util import dt as dt_util
+
+from .api import PiPupError, PiPupUnsupportedError
+from .const import (
+    POWER_OPTIMISTIC_TTL,
+    POWER_SETTLE_DELAY,
+    POWER_STATE_OFF,
+    POWER_STATE_ON,
+)
+from .coordinator import PiPupCoordinator
+from .entity import PiPupEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the screen switch, if the app supports /power."""
+    coordinator: PiPupCoordinator = entry.runtime_data
+    # Needs the fork app >= 0.7.0. Older apps have no /power at all, and a switch
+    # whose every call fails is worse than no switch.
+    if isinstance(coordinator.data.get("power"), dict):
+        async_add_entities([PiPupScreenSwitch(coordinator, entry)])
+
+
+class PiPupScreenSwitch(PiPupEntity, SwitchEntity):
+    """Turns the TV's screen on (wake) and off (standby).
+
+    Whether "off" is possible depends on a one-time adb grant on the device (device
+    admin or the accessibility fallback); the app reports that as
+    ``power.canSleep``. Rather than hiding the switch on devices that lack it, the
+    capability is exposed as an attribute and turning off raises an error naming the
+    fix — a hidden entity leaves you guessing why it never appeared.
+    """
+
+    _attr_translation_key = "screen_power"
+    _attr_device_class = SwitchDeviceClass.SWITCH
+
+    def __init__(self, coordinator: PiPupCoordinator, entry) -> None:
+        """Initialize the switch."""
+        super().__init__(coordinator, entry, "screen_power")
+        self._optimistic: bool | None = None
+        self._optimistic_until = dt_util.utcnow()
+
+    @property
+    def _power(self) -> dict[str, Any]:
+        value = self.coordinator.data.get("power")
+        return value if isinstance(value, dict) else {}
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the screen is on; unknown when unreachable.
+
+        The device reads its own state from PowerManager.isInteractive, which lags a
+        poll behind a fresh wake, so a just-issued state is trusted briefly - until
+        the device confirms it, or the window expires.
+        """
+        reported = self.coordinator.data.get("screenOn")
+        if self._optimistic is not None:
+            if dt_util.utcnow() > self._optimistic_until or reported is self._optimistic:
+                self._optimistic = None
+            else:
+                return self._optimistic
+        if not self.coordinator.online:
+            return None
+        return bool(reported) if reported is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose what this device can actually do with its screen."""
+        power = self._power
+        return {
+            "can_sleep": power.get("canSleep"),
+            "sleep_method": power.get("sleepMethod"),
+        }
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Wake the TV."""
+        await self._set_power(POWER_STATE_ON)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Put the TV in standby."""
+        await self._set_power(POWER_STATE_OFF)
+
+    async def _set_power(self, state: str) -> None:
+        try:
+            await self.coordinator.client.power(state)
+        except PiPupUnsupportedError as err:
+            raise HomeAssistantError(
+                f"{self.entity_id}: this device has no granted way to switch its "
+                "screen off. Grant one over adb (see the PiPup readme): "
+                "`adb shell dpm set-active-admin nl.rogro82.pipup/.AdminReceiver`, "
+                "or enable the accessibility fallback. "
+                f"({err})"
+            ) from err
+        except PiPupError as err:
+            raise HomeAssistantError(f"{self.entity_id}: {err}") from err
+
+        self._optimistic = state == POWER_STATE_ON
+        self._optimistic_until = dt_util.utcnow() + POWER_OPTIMISTIC_TTL
+        self.async_write_ha_state()
+
+        await self.coordinator.async_refresh_soon()
+        # ...and once more after the device settled, so the optimistic value is
+        # replaced by a measured one instead of just timing out.
+        async_call_later(self.hass, POWER_SETTLE_DELAY, self._settle)
+
+    @callback
+    def _settle(self, _now) -> None:
+        self.hass.async_create_task(self.coordinator.async_refresh_soon())

--- a/custom_components/pipup/translations/en.json
+++ b/custom_components/pipup/translations/en.json
@@ -50,7 +50,10 @@
           "default_message_size": "Default message size (0 = app default)",
           "default_title_color": "Default title color (#RRGGBB, empty = app default)",
           "default_message_color": "Default message color (#RRGGBB, empty = app default)",
-          "default_background_color": "Default background color (#AARRGGBB, empty = app default)"
+          "default_background_color": "Default background color (#AARRGGBB, empty = app default)",
+          "default_border_color": "Default border color (empty = none)",
+          "default_border_width": "Default border width in px (empty = none)",
+          "default_corner_radius": "Default corner radius in px (empty = none)"
         },
         "data_description": {
           "name_suffix": "Appended to all entity names of this device (e.g. \"Veranda\" gives \"Popup Veranda\") so multiple TVs stay distinguishable in pickers."
@@ -68,6 +71,9 @@
       },
       "connectivity": {
         "name": "Connectivity"
+      },
+      "permissions": {
+        "name": "Permission problem"
       }
     },
     "notify": {
@@ -106,6 +112,11 @@
     "update": {
       "app_update": {
         "name": "PiPup app"
+      }
+    },
+    "switch": {
+      "screen_power": {
+        "name": "Screen"
       }
     }
   },
@@ -223,6 +234,18 @@
           "name": "Urgency",
           "description": "Styling preset: colored border by severity (app 0.3.0 or newer)."
         },
+        "border_color": {
+          "name": "Border color",
+          "description": "Border color as #RRGGBB or #AARRGGBB. Overrides the urgency preset's color."
+        },
+        "border_width": {
+          "name": "Border width",
+          "description": "Border thickness in pixels. 0 removes the border, also the urgency preset's one."
+        },
+        "corner_radius": {
+          "name": "Corner radius",
+          "description": "Rounded corners in pixels. Works without a border too; 0 keeps them square."
+        },
         "show_progress": {
           "name": "Show countdown bar",
           "description": "Animated bar showing the remaining duration (finite durations only; app 0.3.0 or newer)."
@@ -242,6 +265,12 @@
           "description": "Only dismiss when the visible popup has this ID."
         }
       }
+    }
+  },
+  "issues": {
+    "no_overlay_permission": {
+      "title": "PiPup {name} misses the overlay permission",
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
     }
   }
 }

--- a/custom_components/pipup/translations/nl.json
+++ b/custom_components/pipup/translations/nl.json
@@ -50,7 +50,10 @@
           "default_message_size": "Standaard berichtgrootte (0 = app-standaard)",
           "default_title_color": "Standaard titelkleur (#RRGGBB, leeg = app-standaard)",
           "default_message_color": "Standaard berichtkleur (#RRGGBB, leeg = app-standaard)",
-          "default_background_color": "Standaard achtergrondkleur (#AARRGGBB, leeg = app-standaard)"
+          "default_background_color": "Standaard achtergrondkleur (#AARRGGBB, leeg = app-standaard)",
+          "default_border_color": "Standaard randkleur (leeg = geen)",
+          "default_border_width": "Standaard randdikte in px (leeg = geen)",
+          "default_corner_radius": "Standaard hoekafronding in px (leeg = geen)"
         },
         "data_description": {
           "name_suffix": "Wordt achter alle entiteitsnamen van dit apparaat gezet (bv. \"Veranda\" geeft \"Popup Veranda\") zodat meerdere TV's te onderscheiden zijn in keuzelijsten."
@@ -68,6 +71,9 @@
       },
       "connectivity": {
         "name": "Bereikbaar"
+      },
+      "permissions": {
+        "name": "Permissieprobleem"
       }
     },
     "notify": {
@@ -106,6 +112,11 @@
     "update": {
       "app_update": {
         "name": "PiPup-app"
+      }
+    },
+    "switch": {
+      "screen_power": {
+        "name": "Scherm"
       }
     }
   },
@@ -223,6 +234,18 @@
           "name": "Urgentie",
           "description": "Opmaak-preset: gekleurde rand naar ernst (app 0.3.0 of nieuwer)."
         },
+        "border_color": {
+          "name": "Randkleur",
+          "description": "Randkleur als #RRGGBB of #AARRGGBB. Overschrijft de kleur van de urgentie-preset."
+        },
+        "border_width": {
+          "name": "Randdikte",
+          "description": "Randdikte in pixels. 0 haalt de rand weg, ook die van de urgentie-preset."
+        },
+        "corner_radius": {
+          "name": "Hoekafronding",
+          "description": "Afgeronde hoeken in pixels. Werkt ook zonder rand; 0 houdt ze recht."
+        },
         "show_progress": {
           "name": "Aftelbalk tonen",
           "description": "Geanimeerde balk met de resterende duur (alleen bij eindige duur; app 0.3.0 of nieuwer)."
@@ -242,6 +265,12 @@
           "description": "Alleen sluiten wanneer de zichtbare popup deze ID heeft."
         }
       }
+    }
+  },
+  "issues": {
+    "no_overlay_permission": {
+      "title": "PiPup {name} mist de overlay-permissie",
+      "description": "PiPup op {name} ({host}) heeft de app-op SYSTEM_ALERT_WINDOW niet, en neemt daardoor elke popup aan zonder iets op de tv te tonen. Een app kan dit recht zichzelf niet geven en elke herinstallatie zet het terug. Ken het toe via adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nof draai het installatiescript uit de PiPup-release opnieuw. Deze melding verdwijnt zelf zodra het toestel de permissie meldt."
     }
   }
 }


### PR DESCRIPTION
Companion to [app v0.7.0](https://github.com/mhoogenbosch/PiPup/pull/4). Three features, one release.

## Screen switch (app ≥ 0.7.0)

A **Screen** switch per TV: on = wake, off = standby, both through the app's new `POST /power`. No second ADB/CEC integration needed for the common "wake the TV, then show something".

Turning **on** always works. Turning **off** depends on a one-time adb grant on the device (device admin, or an accessibility fallback for the many boxes that have no device-admin feature), which the app reports as `power.canSleep`. Rather than hiding the entity on those devices, the capability is exposed as `can_sleep` / `sleep_method` attributes and `turn_off` raises an error naming the fix — a silently missing entity leaves you guessing why it never appeared. The switch is only created at all when the app actually has `/power`, so older apps are unaffected.

The app derives screen state from `PowerManager.isInteractive`, which lags a poll behind a fresh wake (measured on hardware). The switch therefore trusts its own last command for 20 s and schedules a settle refresh; without that it visibly bounces back right after you flip it.

## Custom border styling

`border_color`, `border_width` and `corner_radius` on `pipup.show`, each overriding *its part* of the `urgency` preset — `urgency: critical` + `border_width: 2` is a thin red border, `border_width: 0` drops the preset's frame, and `corner_radius` works on a borderless popup. All three are also per-device defaults in the options flow.

Note the deliberate asymmetry with the existing size/color defaults, which treat `0`/`""` as "unset": for these two numeric fields **0 is a real value** (no border, square corners). So an empty options field *removes* the default rather than storing a zero, and a new `pick_numeric()` keeps an explicit 0 from falling through to the app's default.

## Permission reporting

A diagnostic **Permission problem** sensor per TV (each grant as an attribute) plus a **repair issue** when the overlay app-op is missing.

Worth the machinery because this failure is otherwise invisible in HA: without `SYSTEM_ALERT_WINDOW` the TV accepts every popup with HTTP 200 and shows nothing at all — and `adb install -r` resets the app-op, so it comes back after updates. The repair carries the exact adb command, clears itself once the device reports the grant, and the issue registry is only touched when the value changes rather than on every poll.

## Notes

- New platform (`switch`), so this needs an HA restart rather than a reload.
- `strings.json` + `en`/`nl` translations updated for the new action fields, options labels, entities and the repair text.