### PR TITLE
v1.9.1: verify a discovered address before moving an entry to it

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,16 @@ name and a name suffix, done. Because entries key on the app's stable device id,
 working when the TV gets a different DHCP address.
 
 Manual fallback (older app, or discovery blocked between VLANs): Settings → Devices & Services →
-Add Integration → **PiPup** → enter the TV's IP and port (default 7979).
+Add Integration → **PiPup** → enter the TV's IP and port (default 7979). Adding a TV that is already
+configured is also the way to **correct its address**: the flow recognises the device id and moves the
+existing entry to the new IP instead of creating a second one.
+
+> **Why an address can go wrong** (fixed in 1.9.1): PiPup's mDNS service is registered under the
+> *device* hostname, and Android TVs collide there — several sticks claim `Android.local`,
+> `Android-4.local`, … So resolving one TV's service could hand back another TV's address, and the
+> entry would quietly start polling (and showing popups on) the wrong TV, with its own correct device
+> id in the announcement. Since 1.9.1 a discovered address is verified against the device before an
+> existing entry is moved, and a mismatch aborts with `address_mismatch`.
 
 Per-TV popup defaults (position, duration, muted, sizes, colors, border styling) live under
 *Configure* on each entry; action fields override them per call. Note the difference for the two

--- a/custom_components/pipup/__init__.py
+++ b/custom_components/pipup/__init__.py
@@ -65,26 +65,41 @@ async def async_setup_entry(hass: HomeAssistant, entry: PiPupConfigEntry) -> boo
 def _async_track_sw_version(
     hass: HomeAssistant, entry: ConfigEntry, coordinator: PiPupCoordinator
 ) -> None:
-    """Keep the device's firmware field in sync with the app's reported version.
+    """Keep the device's firmware, model and manufacturer in sync with the app.
 
     DeviceInfo is only written when entities are added, so after a self-update
     (app >= 0.6.0 updates itself while HA keeps running) the device page kept
     showing the old version until the entry happened to be reloaded. Watch the
-    coordinator instead and write the new version straight to the registry.
+    coordinator instead and write the new values straight to the registry.
+
+    Model and manufacturer ride along for a nastier reason: if an entry ever polled
+    the wrong TV (see the mDNS hostname collision in config_flow), the registry kept
+    that TV's hardware on the device page long after the address was corrected.
     """
     identifiers = {(DOMAIN, entry.unique_id or entry.entry_id)}
-    last_seen: dict[str, str | None] = {"version": None}
+    last_seen: dict[str, str | None] = {}
 
     @callback
     def _sync() -> None:
-        version = coordinator.data.get("version") if coordinator.data else None
-        if not version or version == last_seen["version"]:
+        data = coordinator.data or {}
+        device_info = data.get("device") or {}
+        wanted = {
+            "sw_version": data.get("version"),
+            "model": device_info.get("model"),
+            "manufacturer": device_info.get("manufacturer"),
+        }
+        wanted = {k: v for k, v in wanted.items() if v}
+        if not wanted or wanted == last_seen:
             return
         registry = dr.async_get(hass)
         device = registry.async_get_device(identifiers=identifiers)
-        if device is not None and device.sw_version != version:
-            registry.async_update_device(device.id, sw_version=version)
-        last_seen["version"] = version
+        if device is not None:
+            changed = {
+                k: v for k, v in wanted.items() if getattr(device, k, None) != v
+            }
+            if changed:
+                registry.async_update_device(device.id, **changed)
+        last_seen.update(wanted)
 
     _sync()
     entry.async_on_unload(coordinator.async_add_listener(_sync))

--- a/custom_components/pipup/config_flow.py
+++ b/custom_components/pipup/config_flow.py
@@ -119,7 +119,21 @@ class PiPupConfigFlow(ConfigFlow, domain=DOMAIN):
         properties = discovery_info.properties
 
         # the app advertises its stable id and device name as TXT records
-        await self.async_set_unique_id(properties.get("id") or f"{host}:{port}")
+        device_id = properties.get("id")
+        await self.async_set_unique_id(device_id or f"{host}:{port}")
+
+        # A discovered address cannot be taken at face value. Android TVs register
+        # their mDNS service under the *device* hostname, and those collide: several
+        # sticks here claim `Android.local`, `Android-4.local`, ... - so resolving one
+        # TV's service can hand back another TV's address. That happened in the field:
+        # an entry silently started polling (and showing popups on) a different TV,
+        # with its own correct device id in the TXT record.
+        #
+        # So before moving an existing entry to a new address, ask the device at that
+        # address who it is.
+        if device_id and not await self._async_host_confirms_id(host, port, device_id):
+            return self.async_abort(reason="address_mismatch")
+
         self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
         # entries created before the app reported ids still key on host:port
         self._async_abort_entries_match({CONF_HOST: host})
@@ -129,6 +143,29 @@ class PiPupConfigFlow(ConfigFlow, domain=DOMAIN):
         self._name = properties.get("name") or host
         self.context["title_placeholders"] = {"name": self._name}
         return await self.async_step_zeroconf_confirm()
+
+    async def _async_host_confirms_id(
+        self, host: str, port: int, device_id: str
+    ) -> bool:
+        """Ask the device at host:port whether it really is device_id.
+
+        Only asked when an entry for this id already exists at a *different* address -
+        the case where trusting a bad mDNS resolution silently moves an entry onto
+        another TV. A device that cannot be reached right now also answers "no", which
+        just means the entry keeps its current address until the next announcement.
+        """
+        entry = next(
+            (e for e in self._async_current_entries() if e.unique_id == device_id),
+            None,
+        )
+        if entry is None or entry.data.get(CONF_HOST) == host:
+            return True  # nothing to move
+        client = PiPupClient(async_get_clientsession(self.hass), host, port)
+        try:
+            state = await client.state()
+        except PiPupError:
+            return False
+        return state.get("id") == device_id
 
     async def async_step_zeroconf_confirm(
         self, user_input: dict[str, Any] | None = None
@@ -142,12 +179,17 @@ class PiPupConfigFlow(ConfigFlow, domain=DOMAIN):
                 async_get_clientsession(self.hass), self._host, self._port
             )
             try:
-                await client.state()
+                state = await client.state()
             except PiPupUnsupportedError:
                 errors["base"] = "unsupported_version"
             except PiPupError:
                 errors["base"] = "cannot_connect"
             else:
+                # Same mDNS hostname collision as in async_step_zeroconf: creating the
+                # entry against the wrong address would give this TV another TV's id.
+                reported = state.get("id")
+                if reported and self.unique_id and reported != self.unique_id:
+                    return self.async_abort(reason="address_mismatch")
                 options = {}
                 if suffix := (user_input.get(CONF_NAME_SUFFIX) or "").strip():
                     options[CONF_NAME_SUFFIX] = suffix

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.9.0",
+  "version": "1.9.1",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/strings.json
+++ b/custom_components/pipup/strings.json
@@ -32,7 +32,8 @@
       "unsupported_version": "This device runs the original PiPup without /state support; install the fork APK first"
     },
     "abort": {
-      "already_configured": "This PiPup device is already configured"
+      "already_configured": "This PiPup device is already configured",
+      "address_mismatch": "The device at this address reports a different PiPup id. Android TVs share generic mDNS hostnames (Android.local), so a discovered service can resolve to another TV's address — ignoring this announcement rather than pointing the entry at the wrong TV."
     }
   },
   "options": {

--- a/custom_components/pipup/translations/en.json
+++ b/custom_components/pipup/translations/en.json
@@ -32,7 +32,8 @@
       "unsupported_version": "This device runs the original PiPup without /state support; install the fork APK first"
     },
     "abort": {
-      "already_configured": "This PiPup device is already configured"
+      "already_configured": "This PiPup device is already configured",
+      "address_mismatch": "The device at this address reports a different PiPup id. Android TVs share generic mDNS hostnames (Android.local), so a discovered service can resolve to another TV's address — ignoring this announcement rather than pointing the entry at the wrong TV."
     }
   },
   "options": {

--- a/custom_components/pipup/translations/nl.json
+++ b/custom_components/pipup/translations/nl.json
@@ -32,7 +32,8 @@
       "unsupported_version": "Dit apparaat draait de originele PiPup zonder /state-ondersteuning; installeer eerst de fork-APK"
     },
     "abort": {
-      "already_configured": "Dit PiPup-apparaat is al geconfigureerd"
+      "already_configured": "Dit PiPup-apparaat is al geconfigureerd",
+      "address_mismatch": "Het toestel op dit adres meldt een andere PiPup-id. Android-tv's delen generieke mDNS-hostnamen (Android.local), waardoor een gevonden service naar het adres van een andere tv kan wijzen — deze aankondiging wordt genegeerd in plaats van de entry op de verkeerde tv te richten."
     }
   },
   "options": {


### PR DESCRIPTION
Found in the field today: the *PiPup TV Atelier* entry was polling — and would have shown popups on — a Fire TV in a child's bedroom. Its `host` had been rewritten to that stick's IP, while its `unique_id` and the mDNS TXT record were both entirely correct.

## Cause

Not the id — the address. The app registers its service through `NsdManager`, which publishes under the **device hostname**, and Android TVs collide there. Measured on this network:

| service | mDNS hostname | address |
| --- | --- | --- |
| PiPup Fire TV - Robyn | `Android` | 192.168.23.235 |
| PiPup Fire TV - Pepijn | `Android-4` | 192.168.25.213 |
| PiPup Fire TV - Veranda | `Android-6` | 192.168.23.26 |

Resolving the Atelier service returned the address of whichever device owned the generic hostname, and `_abort_if_unique_id_configured(updates={CONF_HOST: host})` faithfully moved the entry onto it. The device page then also kept showing the wrong hardware (an Amazon `AFTKA` for a TCL set), because `DeviceInfo` is only written when entities are added.

## Fix

A discovered address is no longer taken at face value:

- Before an **existing** entry is moved, the device at the new address is asked whether it really reports that id. A mismatch — or an unreachable host — aborts with `address_mismatch`, so the entry keeps its current address and the next announcement tries again.
- The zeroconf **confirm** step checks the same thing before creating an entry, so a new TV can never be created against another TV's identity.
- A genuine DHCP change still moves the entry: the device at the new address confirms its own id.

Also: `model` and `manufacturer` are now synced into the device registry alongside `sw_version`, so a device page that picked up the wrong hardware heals on the next poll instead of staying wrong until entities are re-added.

## Recovering an entry that already points at the wrong TV

No downgrade or re-add needed — add the integration again with the **correct** IP. The flow recognises the device id and moves the existing entry (entities, history and automations keep working). That is what repaired the live instance here, before this fix existed.