### PR TITLE
v1.10.0: fix a TV's permissions from Home Assistant

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
   - **Permission problem** diagnostic binary sensor (app ≥ 0.7.0) — on when the app misses a
     permission it needs, with each grant as an attribute. Without the overlay app-op the TV accepts
     every popup with HTTP 200 and shows *nothing*, and `adb install -r` resets it, so this also
-    raises a **repair** with the command to fix it
+    raises a **repair** — one that can now fix itself (app ≥ 0.8.0): pressing *Submit* puts the
+    system's permission screen on the TV, where it takes one press on the remote. The
+    `fixable_on_tv` attribute lists which permissions that works for on this device
+  - **Permission screen** button (app ≥ 0.8.0) — shows PiPup's own permission overview on the TV,
+    with a *Fix* button next to everything that is missing
   - **App uptime** diagnostic sensor and a diagnostics download
 - Action **`pipup.show`** — title/message/media popup with all PiPup fields, plus:
   - `duration: 0` → popup stays until dismissed or replaced
@@ -64,6 +68,12 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
     `corner_radius` also works without a border. Sizes are in pixels, and all three are available as
     **per-device defaults** too
 - Action **`pipup.dismiss`** — remove the popup, optionally only when it has a given `popup_id`.
+- Action **`pipup.fix_permission`** (app ≥ 0.8.0) — put a permission screen on the TV: the app's own
+  overview, the first missing permission, or a specific one. Neither HA nor the app can *grant* these
+  (they are app-ops, i.e. shell/system territory), but walking someone to the exact screen beats
+  telling them to go find an adb prompt. The TV is woken first. Where a device has no such screen —
+  Fire OS answers those intents with placeholders that do nothing — the action fails with the adb
+  command in its message instead of pretending it worked.
 
 ## Installation
 

--- a/custom_components/pipup/__init__.py
+++ b/custom_components/pipup/__init__.py
@@ -10,7 +10,11 @@ from datetime import timedelta
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (  # noqa: F401
@@ -34,6 +38,10 @@ PLATFORMS: list[Platform] = [
 ]
 
 type PiPupConfigEntry = ConfigEntry[PiPupCoordinator]
+
+# There is no YAML configuration: async_setup only registers the domain-wide actions,
+# and every device comes from a config entry.
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/pipup/api.py
+++ b/custom_components/pipup/api.py
@@ -135,6 +135,36 @@ class PiPupClient:
         except (aiohttp.ClientError, TimeoutError) as err:
             raise PiPupError(f"Cannot reach PiPup at {self._base}: {err}") from err
 
+    async def fix_permission(self, what: str | None = None) -> dict[str, Any]:
+        """Ask the TV to put a permission screen in front of the user (app >= 0.8.0).
+
+        `what` picks a specific permission, "next" the first missing one; omitted opens
+        PiPup's own status screen, which lists them all with their own buttons. The app
+        answers 501 when this device has no such screen - Fire OS resolves those intents
+        to do-nothing placeholders - and its reply then carries the adb command instead.
+        """
+        params = {"what": what} if what else None
+        try:
+            async with self._session.post(
+                f"{self._base}/permissions/fix",
+                params=params,
+                timeout=aiohttp.ClientTimeout(total=15),
+            ) as resp:
+                if resp.status in (400, 501):
+                    body = await resp.json(content_type=None)
+                    raise PiPupUnsupportedError(
+                        body.get("adb")
+                        or f"this device cannot open that screen ({resp.status})"
+                    )
+                if resp.status != 200:
+                    body = await resp.text()
+                    raise PiPupError(f"permission fix failed ({resp.status}): {body}")
+                return await resp.json(content_type=None)
+        except PiPupError:
+            raise
+        except (aiohttp.ClientError, TimeoutError) as err:
+            raise PiPupError(f"Cannot reach PiPup at {self._base}: {err}") from err
+
     async def cancel(self, popup_id: str | None = None) -> None:
         """Dismiss the current popup, optionally only when popup_id matches."""
         params = {"id": popup_id} if popup_id else None

--- a/custom_components/pipup/binary_sensor.py
+++ b/custom_components/pipup/binary_sensor.py
@@ -126,7 +126,15 @@ class PiPupPermissionSensor(PiPupEntity, BinarySensorEntity):
         the problem state.
         """
         permissions = self._permissions
+        fixable = permissions.get("fixable")
         return {
+            # which of these the TV can hand to the user on screen (app >= 0.8.0);
+            # the rest needs adb, so a controller should not offer a button for them
+            "fixable_on_tv": (
+                sorted(k for k, v in fixable.items() if v)
+                if isinstance(fixable, dict)
+                else None
+            ),
             "overlay": permissions.get("overlay"),
             "install_packages": permissions.get("installPackages"),
             "auto_start": permissions.get("autoStart"),

--- a/custom_components/pipup/button.py
+++ b/custom_components/pipup/button.py
@@ -6,11 +6,12 @@ https://github.com/tonylofgren/aurora-smart-home
 from __future__ import annotations
 
 from homeassistant.components.button import ButtonEntity
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .api import PiPupError
+from .api import PiPupError, PiPupUnsupportedError
 from .coordinator import PiPupCoordinator
 from .entity import PiPupEntity
 
@@ -20,9 +21,13 @@ async def async_setup_entry(
     entry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the dismiss button."""
+    """Set up the buttons."""
     coordinator: PiPupCoordinator = entry.runtime_data
-    async_add_entities([PiPupDismissButton(coordinator, entry)])
+    buttons: list[ButtonEntity] = [PiPupDismissButton(coordinator, entry)]
+    # Needs the fork app >= 0.8.0.
+    if isinstance((coordinator.data.get("permissions") or {}).get("fixable"), dict):
+        buttons.append(PiPupPermissionScreenButton(coordinator, entry))
+    async_add_entities(buttons)
 
 
 class PiPupDismissButton(PiPupEntity, ButtonEntity):
@@ -38,6 +43,34 @@ class PiPupDismissButton(PiPupEntity, ButtonEntity):
         """Dismiss the current popup."""
         try:
             await self.coordinator.client.cancel()
+        except PiPupError as err:
+            raise HomeAssistantError(str(err)) from err
+        await self.coordinator.async_refresh_soon()
+
+
+class PiPupPermissionScreenButton(PiPupEntity, ButtonEntity):
+    """Puts PiPup's permission screen on the TV (app >= 0.8.0).
+
+    The app cannot grant its own app-ops - that is shell territory - but it can walk
+    someone to the exact screen, which beats telling a person holding a remote to go
+    find an adb prompt. The TV is woken first, and where a device has no such screen
+    (Fire OS answers those intents with do-nothing placeholders) the app shows the adb
+    command instead.
+    """
+
+    _attr_translation_key = "permission_screen"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: PiPupCoordinator, entry) -> None:
+        """Initialize the button."""
+        super().__init__(coordinator, entry, "permission_screen")
+
+    async def async_press(self) -> None:
+        """Show the permission screen on the TV."""
+        try:
+            await self.coordinator.client.fix_permission()
+        except PiPupUnsupportedError as err:
+            raise HomeAssistantError(f"{self.entity_id}: {err}") from err
         except PiPupError as err:
             raise HomeAssistantError(str(err)) from err
         await self.coordinator.async_refresh_soon()

--- a/custom_components/pipup/const.py
+++ b/custom_components/pipup/const.py
@@ -83,6 +83,10 @@ POWER_SETTLE_DELAY: Final = 5
 
 # repair issue raised when the overlay app-op is missing (popups stay invisible)
 ISSUE_NO_OVERLAY: Final = "no_overlay_permission"
+# Same problem, different text: an issue may carry either a description (nothing to
+# press) or a fix flow, never both - and whether the TV can show the screen decides
+# which of the two the user gets.
+ISSUE_NO_OVERLAY_FIXABLE: Final = "no_overlay_permission_fixable"
 
 ATTR_PERMISSION: Final = "permission"
 # "app" opens PiPup's own permission screen, "next" the first missing permission

--- a/custom_components/pipup/const.py
+++ b/custom_components/pipup/const.py
@@ -31,6 +31,7 @@ CONF_NAME_SUFFIX: Final = "name_suffix"
 CONF_NAME_SUFFIX_APPLIED: Final = "name_suffix_applied"
 
 SERVICE_SHOW: Final = "show"
+SERVICE_FIX_PERMISSION: Final = "fix_permission"
 SERVICE_DISMISS: Final = "dismiss"
 
 ATTR_TITLE: Final = "title"
@@ -82,6 +83,10 @@ POWER_SETTLE_DELAY: Final = 5
 
 # repair issue raised when the overlay app-op is missing (popups stay invisible)
 ISSUE_NO_OVERLAY: Final = "no_overlay_permission"
+
+ATTR_PERMISSION: Final = "permission"
+# "app" opens PiPup's own permission screen, "next" the first missing permission
+PERMISSIONS: Final = ["app", "next", "overlay", "install", "admin", "accessibility"]
 
 CAMERA_MODE_STREAM: Final = "stream"
 CAMERA_MODE_MJPEG: Final = "mjpeg"

--- a/custom_components/pipup/coordinator.py
+++ b/custom_components/pipup/coordinator.py
@@ -49,8 +49,6 @@ class PiPupCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             entry.data[CONF_PORT],
         )
         self.online = False
-        # tri-state: None = not yet known, so the first poll always evaluates
-        self._overlay_ok: bool | None = None
 
         scan_interval = entry.options.get(CONF_SCAN_INTERVAL)
         update_interval = (
@@ -95,25 +93,35 @@ class PiPupCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not isinstance(permissions, dict):
             return  # older app: it cannot tell us
         overlay = permissions.get("overlay")
-        if overlay is None or overlay == self._overlay_ok:
+        if overlay is None:
             return
 
-        self._overlay_ok = bool(overlay)
         issue_id = f"{ISSUE_NO_OVERLAY}_{self.config_entry.entry_id}"
+        # Ask the registry rather than remembering the last value: the repair flow
+        # closes the issue while the permission is still missing (someone has to
+        # confirm it on the TV), and this is what raises it again if they did not.
+        exists = ir.async_get(self.hass).async_get_issue(DOMAIN, issue_id) is not None
+
         if overlay:
-            ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            if exists:
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+            return
+        if exists:
             return
         ir.async_create_issue(
             self.hass,
             DOMAIN,
             issue_id,
-            is_fixable=False,
+            # fixable when the app can open the screen itself (app >= 0.8.0); otherwise
+            # only adb can do it and the description carries the command
+            is_fixable=bool((permissions.get("fixable") or {}).get("overlay")),
             severity=ir.IssueSeverity.WARNING,
             translation_key=ISSUE_NO_OVERLAY,
             translation_placeholders={
                 "name": self.config_entry.title,
                 "host": self.client.host,
             },
+            data={"entry_id": self.config_entry.entry_id},
             learn_more_url="https://github.com/mhoogenbosch/PiPup#install",
         )
 

--- a/custom_components/pipup/coordinator.py
+++ b/custom_components/pipup/coordinator.py
@@ -25,6 +25,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     ISSUE_NO_OVERLAY,
+    ISSUE_NO_OVERLAY_FIXABLE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -108,15 +109,16 @@ class PiPupCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             return
         if exists:
             return
+        # fixable when the app can open the screen itself (app >= 0.8.0); otherwise only
+        # adb can do it, and then the issue carries the command as its description
+        fixable = bool((permissions.get("fixable") or {}).get("overlay"))
         ir.async_create_issue(
             self.hass,
             DOMAIN,
             issue_id,
-            # fixable when the app can open the screen itself (app >= 0.8.0); otherwise
-            # only adb can do it and the description carries the command
-            is_fixable=bool((permissions.get("fixable") or {}).get("overlay")),
+            is_fixable=fixable,
             severity=ir.IssueSeverity.WARNING,
-            translation_key=ISSUE_NO_OVERLAY,
+            translation_key=ISSUE_NO_OVERLAY_FIXABLE if fixable else ISSUE_NO_OVERLAY,
             translation_placeholders={
                 "name": self.config_entry.title,
                 "host": self.client.host,

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.9.1",
+  "version": "1.10.0",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/repairs.py
+++ b/custom_components/pipup/repairs.py
@@ -1,0 +1,67 @@
+"""Repair flow for a PiPup TV that is missing its overlay permission."""
+from __future__ import annotations
+
+import voluptuous as vol
+
+from homeassistant.components.repairs import RepairsFlow
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .api import PiPupError, PiPupUnsupportedError
+
+
+class OverlayPermissionRepairFlow(RepairsFlow):
+    """Walks the user to the screen where the overlay permission is granted.
+
+    Home Assistant cannot grant it and neither can the app: `appops` is shell/system
+    territory. What the app *can* do is put the right system screen on the TV, so the
+    fix here is "press this, then pick up the remote" - and on devices that have no such
+    screen (Fire OS answers those intents with do-nothing placeholders) the flow says so
+    and hands over the adb command instead of pretending.
+    """
+
+    def __init__(self, entry_id: str) -> None:
+        """Initialize the flow."""
+        self._entry_id = entry_id
+
+    async def async_step_init(
+        self, user_input: dict[str, str] | None = None
+    ):
+        """Start the flow."""
+        return await self.async_step_confirm()
+
+    async def async_step_confirm(
+        self, user_input: dict[str, str] | None = None
+    ):
+        """Ask the TV to show the overlay permission screen."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="confirm", data_schema=vol.Schema({})
+            )
+
+        entry = self.hass.config_entries.async_get_entry(self._entry_id)
+        if entry is None or entry.state is not ConfigEntryState.LOADED:
+            return self.async_abort(reason="not_loaded")
+
+        coordinator = entry.runtime_data
+        try:
+            await coordinator.client.fix_permission("overlay")
+        except PiPupUnsupportedError:
+            return self.async_abort(reason="use_adb")
+        except PiPupError:
+            return self.async_abort(reason="cannot_connect")
+
+        # The permission is not granted yet - someone still has to confirm it on the TV.
+        # Closing the issue here is fine: the coordinator raises it again on the next
+        # poll if the device still reports the permission as missing.
+        return self.async_create_entry(data={})
+
+
+async def async_create_fix_flow(
+    hass: HomeAssistant,
+    issue_id: str,
+    data: dict[str, str | int | float | None] | None,
+) -> RepairsFlow:
+    """Create the flow for a repair issue."""
+    entry_id = str((data or {}).get("entry_id", ""))
+    return OverlayPermissionRepairFlow(entry_id)

--- a/custom_components/pipup/services.py
+++ b/custom_components/pipup/services.py
@@ -20,9 +20,10 @@ from homeassistant.helpers.network import get_url
 from homeassistant.helpers.service import async_extract_config_entry_ids
 from homeassistant.util import dt as dt_util
 
-from .api import PiPupError
+from .api import PiPupError, PiPupUnsupportedError
 from .const import (
     ATTR_BACKGROUND_COLOR,
+    ATTR_PERMISSION,
     ATTR_BORDER_COLOR,
     ATTR_BORDER_WIDTH,
     ATTR_BUTTONS,
@@ -68,9 +69,11 @@ from .const import (
     DATA_BUTTON_TOKENS,
     DEFAULT_POSITION,
     DOMAIN,
+    PERMISSIONS,
     EVENT_BUTTON,
     POSITIONS,
     SERVICE_DISMISS,
+    SERVICE_FIX_PERMISSION,
     SERVICE_SHOW,
     URGENCIES,
     WEBHOOK_ID,
@@ -139,6 +142,13 @@ SHOW_SCHEMA = vol.Schema(
         ),
     },
     extra=vol.ALLOW_EXTRA,  # allow target fields (device_id etc.)
+)
+
+FIX_PERMISSION_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_PERMISSION, default="app"): vol.In(PERMISSIONS),
+    },
+    extra=vol.ALLOW_EXTRA,
 )
 
 DISMISS_SCHEMA = vol.Schema(
@@ -477,8 +487,34 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         if errors:
             raise HomeAssistantError("; ".join(errors))
 
+    async def handle_fix_permission(call: ServiceCall) -> None:
+        """Put a permission screen on the TV(s) in the target.
+
+        Errors are collected rather than raised per device: with several TVs targeted,
+        the ones that *can* show a screen should still do so, and the message names the
+        ones that need adb (the app returns the exact command).
+        """
+        coordinators = await _coordinators_for_call(hass, call)
+        what = call.data.get(ATTR_PERMISSION, "app")
+
+        errors: list[str] = []
+        for coordinator in coordinators:
+            try:
+                await coordinator.client.fix_permission(None if what == "app" else what)
+            except (PiPupError, PiPupUnsupportedError) as err:
+                errors.append(f"{coordinator.client.host}: {err}")
+
+        if errors:
+            raise HomeAssistantError("; ".join(errors))
+
     hass.services.async_register(
         DOMAIN, SERVICE_SHOW, handle_show, schema=SHOW_SCHEMA
+    )
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_FIX_PERMISSION,
+        handle_fix_permission,
+        schema=FIX_PERMISSION_SCHEMA,
     )
     hass.services.async_register(
         DOMAIN, SERVICE_DISMISS, handle_dismiss, schema=DISMISS_SCHEMA

--- a/custom_components/pipup/services.yaml
+++ b/custom_components/pipup/services.yaml
@@ -144,3 +144,21 @@ dismiss:
     popup_id:
       selector:
         text:
+
+fix_permission:
+  target:
+    entity:
+      integration: pipup
+  fields:
+    permission:
+      default: app
+      selector:
+        select:
+          options:
+            - app
+            - next
+            - overlay
+            - install
+            - admin
+            - accessibility
+          translation_key: permission

--- a/custom_components/pipup/strings.json
+++ b/custom_components/pipup/strings.json
@@ -294,7 +294,10 @@
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} misses the overlay permission",
-      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission.",
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
+    },
+    "no_overlay_permission_fixable": {
+      "title": "PiPup {name} misses the overlay permission",
       "fix_flow": {
         "step": {
           "confirm": {

--- a/custom_components/pipup/strings.json
+++ b/custom_components/pipup/strings.json
@@ -96,6 +96,9 @@
     "button": {
       "dismiss": {
         "name": "Dismiss popup"
+      },
+      "permission_screen": {
+        "name": "Permission screen"
       }
     },
     "select": {
@@ -143,6 +146,16 @@
         "info": "Info (blue border)",
         "warning": "Warning (orange border)",
         "critical": "Critical (red border)"
+      }
+    },
+    "permission": {
+      "options": {
+        "app": "PiPup overview",
+        "next": "First missing one",
+        "overlay": "Overlay permission",
+        "install": "Self-update permission",
+        "admin": "Screen off (device admin)",
+        "accessibility": "Screen off (accessibility)"
       }
     }
   },
@@ -266,12 +279,35 @@
           "description": "Only dismiss when the visible popup has this ID."
         }
       }
+    },
+    "fix_permission": {
+      "name": "Fix permission",
+      "description": "Puts a permission screen on the TV so it can be granted with the remote. The app cannot grant these itself; where a device has no such screen it shows the adb command instead.",
+      "fields": {
+        "permission": {
+          "name": "Permission",
+          "description": "Which screen to open: the app's own overview, the first missing permission, or a specific one."
+        }
+      }
     }
   },
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} misses the overlay permission",
-      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Show the permission screen on the TV",
+            "description": "Press Submit and PiPup opens the overlay permission screen on {name}. Switch to the TV and turn the permission on with the remote — Home Assistant cannot do that part; it is a system screen.\\n\\nThe warning disappears by itself once the TV reports the permission."
+          }
+        },
+        "abort": {
+          "use_adb": "This TV has no screen for that permission (Fire TV, for instance, answers with a placeholder that does nothing). Grant it over adb instead:\\n\\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`",
+          "cannot_connect": "The TV did not answer. Try again when it is reachable.",
+          "not_loaded": "This PiPup device is not loaded right now."
+        }
+      }
     }
   }
 }

--- a/custom_components/pipup/translations/en.json
+++ b/custom_components/pipup/translations/en.json
@@ -294,7 +294,10 @@
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} misses the overlay permission",
-      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission.",
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
+    },
+    "no_overlay_permission_fixable": {
+      "title": "PiPup {name} misses the overlay permission",
       "fix_flow": {
         "step": {
           "confirm": {

--- a/custom_components/pipup/translations/en.json
+++ b/custom_components/pipup/translations/en.json
@@ -96,6 +96,9 @@
     "button": {
       "dismiss": {
         "name": "Dismiss popup"
+      },
+      "permission_screen": {
+        "name": "Permission screen"
       }
     },
     "select": {
@@ -143,6 +146,16 @@
         "info": "Info (blue border)",
         "warning": "Warning (orange border)",
         "critical": "Critical (red border)"
+      }
+    },
+    "permission": {
+      "options": {
+        "app": "PiPup overview",
+        "next": "First missing one",
+        "overlay": "Overlay permission",
+        "install": "Self-update permission",
+        "admin": "Screen off (device admin)",
+        "accessibility": "Screen off (accessibility)"
       }
     }
   },
@@ -266,12 +279,35 @@
           "description": "Only dismiss when the visible popup has this ID."
         }
       }
+    },
+    "fix_permission": {
+      "name": "Fix permission",
+      "description": "Puts a permission screen on the TV so it can be granted with the remote. The app cannot grant these itself; where a device has no such screen it shows the adb command instead.",
+      "fields": {
+        "permission": {
+          "name": "Permission",
+          "description": "Which screen to open: the app's own overview, the first missing permission, or a specific one."
+        }
+      }
     }
   },
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} misses the overlay permission",
-      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission."
+      "description": "PiPup on {name} ({host}) does not have the SYSTEM_ALERT_WINDOW app-op, so it accepts every popup but shows nothing on the TV. An app cannot grant this to itself and every reinstall resets it. Grant it over adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nor re-run the installer script from the PiPup release. This message disappears by itself once the device reports the permission.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Show the permission screen on the TV",
+            "description": "Press Submit and PiPup opens the overlay permission screen on {name}. Switch to the TV and turn the permission on with the remote — Home Assistant cannot do that part; it is a system screen.\\n\\nThe warning disappears by itself once the TV reports the permission."
+          }
+        },
+        "abort": {
+          "use_adb": "This TV has no screen for that permission (Fire TV, for instance, answers with a placeholder that does nothing). Grant it over adb instead:\\n\\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`",
+          "cannot_connect": "The TV did not answer. Try again when it is reachable.",
+          "not_loaded": "This PiPup device is not loaded right now."
+        }
+      }
     }
   }
 }

--- a/custom_components/pipup/translations/nl.json
+++ b/custom_components/pipup/translations/nl.json
@@ -96,6 +96,9 @@
     "button": {
       "dismiss": {
         "name": "Popup sluiten"
+      },
+      "permission_screen": {
+        "name": "Permissiescherm"
       }
     },
     "select": {
@@ -143,6 +146,16 @@
         "info": "Info (blauwe rand)",
         "warning": "Waarschuwing (oranje rand)",
         "critical": "Kritiek (rode rand)"
+      }
+    },
+    "permission": {
+      "options": {
+        "app": "PiPup-overzicht",
+        "next": "Eerste die ontbreekt",
+        "overlay": "Overlay-permissie",
+        "install": "Zelf-updaten",
+        "admin": "Scherm uit (apparaatbeheerder)",
+        "accessibility": "Scherm uit (toegankelijkheid)"
       }
     }
   },
@@ -266,12 +279,35 @@
           "description": "Alleen sluiten wanneer de zichtbare popup deze ID heeft."
         }
       }
+    },
+    "fix_permission": {
+      "name": "Permissie repareren",
+      "description": "Zet een permissiescherm op de tv, zodat je het met de afstandsbediening kunt toekennen. De app kan deze rechten zichzelf niet geven; heeft een toestel zo'n scherm niet, dan toont hij het adb-commando.",
+      "fields": {
+        "permission": {
+          "name": "Permissie",
+          "description": "Welk scherm er opengaat: het overzicht van de app zelf, de eerste die ontbreekt, of een specifieke."
+        }
+      }
     }
   },
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} mist de overlay-permissie",
-      "description": "PiPup op {name} ({host}) heeft de app-op SYSTEM_ALERT_WINDOW niet, en neemt daardoor elke popup aan zonder iets op de tv te tonen. Een app kan dit recht zichzelf niet geven en elke herinstallatie zet het terug. Ken het toe via adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nof draai het installatiescript uit de PiPup-release opnieuw. Deze melding verdwijnt zelf zodra het toestel de permissie meldt."
+      "description": "PiPup op {name} ({host}) heeft de app-op SYSTEM_ALERT_WINDOW niet, en neemt daardoor elke popup aan zonder iets op de tv te tonen. Een app kan dit recht zichzelf niet geven en elke herinstallatie zet het terug. Ken het toe via adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nof draai het installatiescript uit de PiPup-release opnieuw. Deze melding verdwijnt zelf zodra het toestel de permissie meldt.",
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "title": "Permissiescherm op de tv tonen",
+            "description": "Druk op Verzenden en PiPup opent het overlay-permissiescherm op {name}. Pak daarna de afstandsbediening en zet de permissie aan — dat deel kan Home Assistant niet doen, het is een systeemscherm.\\n\\nDe melding verdwijnt vanzelf zodra de tv de permissie meldt."
+          }
+        },
+        "abort": {
+          "use_adb": "Deze tv heeft geen scherm voor die permissie (Fire TV antwoordt bijvoorbeeld met een lege placeholder). Ken 'm toe via adb:\\n\\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`",
+          "cannot_connect": "De tv antwoordde niet. Probeer het opnieuw als hij bereikbaar is.",
+          "not_loaded": "Dit PiPup-apparaat is nu niet geladen."
+        }
+      }
     }
   }
 }

--- a/custom_components/pipup/translations/nl.json
+++ b/custom_components/pipup/translations/nl.json
@@ -294,7 +294,10 @@
   "issues": {
     "no_overlay_permission": {
       "title": "PiPup {name} mist de overlay-permissie",
-      "description": "PiPup op {name} ({host}) heeft de app-op SYSTEM_ALERT_WINDOW niet, en neemt daardoor elke popup aan zonder iets op de tv te tonen. Een app kan dit recht zichzelf niet geven en elke herinstallatie zet het terug. Ken het toe via adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nof draai het installatiescript uit de PiPup-release opnieuw. Deze melding verdwijnt zelf zodra het toestel de permissie meldt.",
+      "description": "PiPup op {name} ({host}) heeft de app-op SYSTEM_ALERT_WINDOW niet, en neemt daardoor elke popup aan zonder iets op de tv te tonen. Een app kan dit recht zichzelf niet geven en elke herinstallatie zet het terug. Ken het toe via adb:\n\n`adb shell appops set nl.rogro82.pipup SYSTEM_ALERT_WINDOW allow`\n\nof draai het installatiescript uit de PiPup-release opnieuw. Deze melding verdwijnt zelf zodra het toestel de permissie meldt."
+    },
+    "no_overlay_permission_fixable": {
+      "title": "PiPup {name} mist de overlay-permissie",
       "fix_flow": {
         "step": {
           "confirm": {


### PR DESCRIPTION
Companion to [app v0.8.0](https://github.com/mhoogenbosch/PiPup/pull/7). The permission sensor and repair from 1.9.0 could only tell you something was wrong; now HA can also put the screen that fixes it on the TV, where it takes one press on the remote.

- **`pipup.fix_permission`** action — the app's own overview, the first missing permission, or a specific one. Errors are collected per device rather than aborting the whole call, so targeting several TVs still helps the ones that can.
- **Permission screen** button per TV (config category), only created when the app reports the capability.
- **The overlay repair is now fixable** where the device can do it: pressing *Submit* opens the system screen on the TV. Where it cannot (Fire OS answers those intents with placeholders that do nothing) the flow aborts with the adb command instead.
- **`fixable_on_tv`** attribute on the permission sensor, so a dashboard can show a button only where it leads somewhere.

Neither HA nor the app can *grant* these — they are app-ops, i.e. shell/system territory — and nothing here pretends otherwise.

### One subtlety worth flagging

The repair flow closes its issue while the permission is still missing: someone has to confirm it on the TV afterwards. That means the coordinator can no longer decide by comparing against the last value it saw — it now asks the issue registry whether the issue exists, and raises it again on the next poll if the permission is still not there. Without that, dismissing the repair would have silently buried the problem for good.