### PR TITLE
v1.10.1: schedule the reload instead of awaiting it in the update listener

### DIFF
--- a/custom_components/pipup/__init__.py
+++ b/custom_components/pipup/__init__.py
@@ -188,7 +188,10 @@ async def _async_update_listener(hass: HomeAssistant, entry: PiPupConfigEntry) -
         timedelta(seconds=scan_interval) if scan_interval else DEFAULT_SCAN_INTERVAL
     )
     if coordinator.update_interval != desired:
-        await hass.config_entries.async_reload(entry.entry_id)
+        # Schedule rather than await: awaiting a reload from inside the entry's own
+        # update listener races with setup-retry (and HA warns that awaiting it here
+        # stops working in 2026.12).
+        hass.config_entries.async_schedule_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: PiPupConfigEntry) -> bool:

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.10.0",
+  "version": "1.10.1",
   "zeroconf": [
     "_pipup._tcp.local."
   ]


### PR DESCRIPTION
Spotted in the log after the 1.10.0 restart:

> Detected that custom integration 'pipup' has an update listener and should use it for scheduling a reload. **This will stop working in Home Assistant 2026.12.0**

Awaiting `async_reload` from inside the entry's own update listener races with setup retry; `async_schedule_reload` cancels the retry first and runs the reload in a task. Core's own docstring recommends it for exactly this case.

Only reached when the scan interval changes, so nothing else about the behaviour changes. Not urgent — but the deadline is a release away and the fix is one line.