### PR TITLE
v1.11.0: carry the app's permission diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ Every version below has a [GitHub release](https://github.com/mhoogenbosch/ha-pi
 full story in English and Dutch. Features marked *(app ≥ x.y.z)* need a matching version of the
 [PiPup app](https://github.com/mhoogenbosch/PiPup) on the TV.
 
+## [v1.11.0] — 2026-08-19 (carry the app's permission diagnosis)
+Companion to [app v0.9.0](https://github.com/mhoogenbosch/PiPup/releases/tag/v0.9.0).
+### Added
+- The **diagnostics download** now includes the app's own permission diagnosis *(app ≥ 0.9.0)*: per
+  permission which activity handles its settings screen, whether that is a vendor placeholder, whether a
+  background activity launch is allowed at all, and how the last fix attempt ended. That file is what to
+  attach to a "the fix button does nothing" report, instead of asking the reporter for adb and a logcat.
+### Changed
+- `pipup.fix_permission` failures now carry the app's own explanation. App ≥ 0.9.0 returns a `reason` —
+  most usefully that Android blocks starting an activity from the background unless the overlay
+  permission is granted, which is exactly the case people press this for — and the message passes that
+  through with the adb command appended, rather than a generic failure.
+
 ## [v1.10.1] — 2026-08-17 (schedule the reload in the update listener)
 ### Fixed
 - Home Assistant logged *"Detected that custom integration 'pipup' has an update listener and should use

--- a/README.md
+++ b/README.md
@@ -41,7 +41,10 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
     `fixable_on_tv` attribute lists which permissions that works for on this device
   - **Permission screen** button (app ≥ 0.8.0) — shows PiPup's own permission overview on the TV,
     with a *Fix* button next to everything that is missing
-  - **App uptime** diagnostic sensor and a diagnostics download
+  - **App uptime** diagnostic sensor and a diagnostics download — which, with app ≥ 0.9.0, includes
+    the app's own permission diagnosis (which activity handles each settings screen, whether it is a
+    vendor placeholder, whether a background launch is allowed, how the last attempt ended). That file
+    is what to attach to a "the fix button does nothing" report
 - Action **`pipup.show`** — title/message/media popup with all PiPup fields, plus:
   - `duration: 0` → popup stays until dismissed or replaced
   - `popup_id` → re-sending the same id+content only extends the timer (stream keeps playing, no flicker)
@@ -74,6 +77,13 @@ Requires the [PiPup fork APK](https://github.com/mhoogenbosch/PiPup/releases) on
   telling them to go find an adb prompt. The TV is woken first. Where a device has no such screen —
   Fire OS answers those intents with placeholders that do nothing — the action fails with the adb
   command in its message instead of pretending it worked.
+
+  ⚠️ **The overlay permission itself cannot be fixed remotely.** Android blocks background activity
+  starts unless the app holds `SYSTEM_ALERT_WINDOW`, so the one permission you most want this for is
+  the one whose absence takes it away — and a blocked launch is dropped silently by the platform. App
+  ≥ 0.9.0 says so in the error instead of failing quietly. The way out: open PiPup on the TV (from the
+  launcher, or by tapping its ongoing notification) and use the button on its status screen, or grant
+  it over adb. Everything else opens fine with the app in the background.
 
 ## Installation
 

--- a/custom_components/pipup/api.py
+++ b/custom_components/pipup/api.py
@@ -152,8 +152,17 @@ class PiPupClient:
             ) as resp:
                 if resp.status in (400, 501):
                     body = await resp.json(content_type=None)
+                    # The app explains itself (app >= 0.9.0 sends `reason`, e.g. that
+                    # Android blocks a background activity start without the overlay
+                    # permission); pass that through rather than a generic failure, and
+                    # append the adb command so the message is actionable on its own.
+                    parts = [
+                        part
+                        for part in (body.get("reason"), body.get("adb"))
+                        if part
+                    ]
                     raise PiPupUnsupportedError(
-                        body.get("adb")
+                        " - ".join(parts)
                         or f"this device cannot open that screen ({resp.status})"
                     )
                 if resp.status != 200:
@@ -164,6 +173,25 @@ class PiPupClient:
             raise
         except (aiohttp.ClientError, TimeoutError) as err:
             raise PiPupError(f"Cannot reach PiPup at {self._base}: {err}") from err
+
+    async def diagnose(self) -> dict[str, Any] | None:
+        """Fetch /permissions/diagnose (app >= 0.9.0), or None on an older app.
+
+        Rides along in the integration's diagnostics download so a bug report carries
+        the per-permission facts - which activity resolves each settings screen, whether
+        it is a vendor placeholder, whether a background launch is even allowed - instead
+        of the reporter being asked for adb and a logcat.
+        """
+        try:
+            async with self._session.get(
+                f"{self._base}/permissions/diagnose",
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as resp:
+                if resp.status != 200:
+                    return None
+                return await resp.json(content_type=None)
+        except (aiohttp.ClientError, TimeoutError):
+            return None
 
     async def cancel(self, popup_id: str | None = None) -> None:
         """Dismiss the current popup, optionally only when popup_id matches."""

--- a/custom_components/pipup/diagnostics.py
+++ b/custom_components/pipup/diagnostics.py
@@ -25,4 +25,9 @@ async def async_get_config_entry_diagnostics(
         },
         "state": coordinator.data,
         "last_update_success": coordinator.last_update_success,
+        # Fetched live (app >= 0.9.0): per permission which activity resolves its
+        # settings screen, whether that is a vendor placeholder, whether a background
+        # activity launch is allowed at all, and how the last fix attempt ended. This is
+        # the file to attach to a "the fix button does nothing" report.
+        "permission_diagnose": await coordinator.client.diagnose(),
     }

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.10.1",
+  "version": "1.11.0",
   "zeroconf": [
     "_pipup._tcp.local."
   ]


### PR DESCRIPTION
Companion to [app v0.9.0](https://github.com/mhoogenbosch/PiPup/pull/12), in answer to a field report that the permission fix "does not work".

- The **diagnostics download** now includes the app's `/permissions/diagnose` block *(app ≥ 0.9.0)*: per permission which activity handles its settings screen, whether that is a vendor placeholder, whether a background activity launch is allowed at all, and how the last fix attempt ended. That file is what a report should carry — the alternative is asking someone with a remote in their hand for adb and a logcat.
- **`pipup.fix_permission` failures carry the app's own explanation.** App ≥ 0.9.0 returns a `reason`, most usefully that Android blocks starting an activity from the background unless the overlay permission is granted — which is exactly the case people press this for. The message passes that through with the adb command appended, instead of a generic failure.

Older apps are unaffected: the diagnose fetch returns `None` and the message falls back to what it was.
