### PR TITLE
v1.11.1: say why an app update failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ Every version below has a [GitHub release](https://github.com/mhoogenbosch/ha-pi
 full story in English and Dutch. Features marked *(app ≥ x.y.z)* need a matching version of the
 [PiPup app](https://github.com/mhoogenbosch/PiPup) on the TV.
 
+## [v1.11.1] — 2026-08-22 (say why an app update failed)
+### Added
+- The **PiPup app** update entity now exposes `install_error` (the app's own reason from `/state`,
+  e.g. a failed download or a rejected install session), `install_permission` (false after any
+  `adb install -r`, which resets the app-op) and `requires_remote` (Android < 12 shows the system's
+  install confirmation **on the TV**, which someone has to accept with the remote — without knowing
+  that, a pending install looks like a hang). Field report: "the update failed" with nothing anywhere
+  in HA saying why, while the app had the reason all along.
+
 ## [v1.11.0] — 2026-08-19 (carry the app's permission diagnosis)
 Companion to [app v0.9.0](https://github.com/mhoogenbosch/PiPup/releases/tag/v0.9.0).
 ### Added

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.11.0",
+  "version": "1.11.1",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/update.py
+++ b/custom_components/pipup/update.py
@@ -125,6 +125,28 @@ class PiPupUpdateEntity(PiPupEntity, UpdateEntity):
         """True while the TV is downloading/installing the update."""
         return bool((self.coordinator.data.get("update") or {}).get("installing"))
 
+    @property
+    def extra_state_attributes(self) -> dict[str, str | bool | None]:
+        """Expose why an install did not land.
+
+        Field report: "the update failed" with nothing anywhere in HA saying why,
+        while the app had the reason in /state all along. Two usual causes, both
+        now visible here: a missing install permission (an `adb install -r` resets
+        it), and Android < 12, where the system shows a confirmation dialog ON THE
+        TV that someone has to accept with the remote - `requires_remote` says so
+        up front instead of letting that look like a hang.
+        """
+        update = self.coordinator.data.get("update") or {}
+        device = self.coordinator.data.get("device") or {}
+        permissions = self.coordinator.data.get("permissions") or {}
+        android = str(device.get("android") or "")
+        major = int(android.split(".")[0]) if android.split(".")[0].isdigit() else None
+        return {
+            "install_error": update.get("error"),
+            "install_permission": permissions.get("installPackages"),
+            "requires_remote": major is not None and major < 12,
+        }
+
     async def async_install(self, version: str | None, backup: bool, **kwargs) -> None:
         """Trigger the app's self-update on the TV.
 


### PR DESCRIPTION
Field report (HA forum): *"The Integration saw the TVs needed to be updated, but it failed"* — with nothing anywhere in HA saying **why**, while the app had the reason in `/state` all along.

The **PiPup app** update entity now exposes three attributes:

- **`install_error`** — the app's own message (failed download, rejected install session, …);
- **`install_permission`** — the `REQUEST_INSTALL_PACKAGES` app-op. Worth its own attribute because any `adb install -r` silently resets it, so "I granted it long ago" is routinely true *and* irrelevant;
- **`requires_remote`** — Android < 12 cannot install silently: the system shows its confirmation **on the TV**, and someone has to accept it with the remote. Without knowing that, a pending install looks like a hang (measured earlier on a Fire OS 9 stick: an install session sat waiting on a screen that was off).

Companion to [app v0.10.0](https://github.com/mhoogenbosch/PiPup/pull/14), which fixes the other half of the same report (the permission panel presented optional power grants as a permanent problem).
