### PR TITLE
v1.11.2: audit fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ Every version below has a [GitHub release](https://github.com/mhoogenbosch/ha-pi
 full story in English and Dutch. Features marked *(app ≥ x.y.z)* need a matching version of the
 [PiPup app](https://github.com/mhoogenbosch/PiPup) on the TV.
 
+## [v1.11.2] — 2026-08-22 (audit fixes)
+### Fixed
+- **An indefinite camera popup could go dark after 24 hours** when the *per-device default* duration
+  was 0 (indefinite) and the `pipup.show` call did not pass a duration itself: the MJPEG URL was signed
+  for 24 h because only an explicit `duration: 0` in the call got the long signature. Only an explicit,
+  finite duration now gets the short signature; everything else gets 30 days (a longer signature on a
+  short popup costs nothing).
+- The screen switch's settle-refresh timer is now cancelled when the entity is removed (and when a new
+  toggle supersedes it) — it could fire after an entry unload and poke an unloaded coordinator.
+
 ## [v1.11.1] — 2026-08-22 (say why an app update failed)
 ### Added
 - The **PiPup app** update entity now exposes `install_error` (the app's own reason from `/state`,

--- a/custom_components/pipup/manifest.json
+++ b/custom_components/pipup/manifest.json
@@ -16,7 +16,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/mhoogenbosch/ha-pipup/issues",
   "requirements": [],
-  "version": "1.11.1",
+  "version": "1.11.2",
   "zeroconf": [
     "_pipup._tcp.local."
   ]

--- a/custom_components/pipup/services.py
+++ b/custom_components/pipup/services.py
@@ -325,12 +325,17 @@ async def _camera_media(
 
         # An indefinite popup (duration <= 0) keeps the same signed URL open for
         # as long as it is shown, so a 24 h signature would make the stream go
-        # 401 after a day. Sign such popups for much longer.
+        # 401 after a day. The call's duration is not the whole story: a missing
+        # duration falls back to the PER-DEVICE default, which since 1.7.0 may
+        # itself be 0 (indefinite) - and this helper cannot know which TV it is
+        # signing for. So only an explicit, finite duration gets the short
+        # signature; everything else gets the long one (a longer signature on a
+        # short popup costs nothing).
         duration = data.get(ATTR_DURATION)
         expiry = (
-            timedelta(days=30)
-            if duration is not None and duration <= 0
-            else timedelta(hours=24)
+            timedelta(hours=24)
+            if duration is not None and duration > 0
+            else timedelta(days=30)
         )
         signed = async_sign_path(
             hass,

--- a/custom_components/pipup/switch.py
+++ b/custom_components/pipup/switch.py
@@ -52,6 +52,7 @@ class PiPupScreenSwitch(PiPupEntity, SwitchEntity):
         super().__init__(coordinator, entry, "screen_power")
         self._optimistic: bool | None = None
         self._optimistic_until = dt_util.utcnow()
+        self._cancel_settle: callable | None = None
 
     @property
     def _power(self) -> dict[str, Any]:
@@ -113,9 +114,23 @@ class PiPupScreenSwitch(PiPupEntity, SwitchEntity):
 
         await self.coordinator.async_refresh_soon()
         # ...and once more after the device settled, so the optimistic value is
-        # replaced by a measured one instead of just timing out.
-        async_call_later(self.hass, POWER_SETTLE_DELAY, self._settle)
+        # replaced by a measured one instead of just timing out. Cancel any
+        # earlier pending settle first, and cancel on removal: a timer that
+        # outlives the entity would poke an unloaded coordinator.
+        if self._cancel_settle is not None:
+            self._cancel_settle()
+        self._cancel_settle = async_call_later(
+            self.hass, POWER_SETTLE_DELAY, self._settle
+        )
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Cancel the pending settle refresh."""
+        if self._cancel_settle is not None:
+            self._cancel_settle()
+            self._cancel_settle = None
+        await super().async_will_remove_from_hass()
 
     @callback
     def _settle(self, _now) -> None:
+        self._cancel_settle = None
         self.hass.async_create_task(self.coordinator.async_refresh_soon())


### PR DESCRIPTION
Two verified findings from a full audit of the integration (companion to [PiPup v0.10.1](https://github.com/mhoogenbosch/PiPup/pull/15)).

**1. An indefinite camera popup could go dark after 24 hours.** `_camera_media` decides the MJPEG signature lifetime from the *call's* `duration` only — but a missing duration falls back to the **per-device default**, which since 1.7.0 may itself be `0` (indefinite). So `pipup.show` with `camera_entity` and no explicit duration, on a TV whose default duration is 0, produced an indefinite popup holding a 24-hour URL: the stream 401s after a day while the popup stays up. Only an explicit, *finite* duration now gets the 24 h signature; everything else gets 30 days. A longer signature on a short popup costs nothing.

**2. The screen switch's settle timer could outlive its entity.** The post-toggle refresh (`async_call_later`) was never cancelled — after an entry unload it would still fire and poke an unloaded coordinator. It is now stored, superseded on a new toggle, and cancelled in `async_will_remove_from_hass`.

Also checked and found sound: the single-use button-token flow (local-only webhook, expiry sweep, pop-before-check), the config/zeroconf flows including the 1.9.1 address verification, the never-unavailable coordinator model, the options merging, and the update entity's shared GitHub cache.
